### PR TITLE
Production deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,24 @@ jobs:
       - run:
           name: Push
           command: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
-  deploy:
+
+  deploy-staging:
+    docker:
+      - image: artsy/hokusai
+    steps:
+      - add_ssh_keys
+      - checkout
+      - run:
+          name: Configure
+          command: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
+      - run:
+          name: Update staging branch
+          command: git push git@github.com:artsy/kaws.git $CIRCLE_SHA1:staging --force
+      - run:
+          name: Deploy
+          command: hokusai staging deploy $CIRCLE_SHA1 --git-remote origin
+
+  deploy-production:
     docker:
       - image: artsy/hokusai
     steps:
@@ -31,7 +48,8 @@ jobs:
           command: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
       - run:
           name: Deploy
-          command: hokusai staging deploy $CIRCLE_SHA1 --git-remote origin
+          command: hokusai production deploy $CIRCLE_SHA1 --git-remote origin
+
 workflows:
   version: 2
   default:
@@ -47,10 +65,15 @@ workflows:
               only: master
           requires:
             - test
-      - deploy:
+      - deploy-staging:
           filters:
             branches:
               only: master
           requires:
             - push
-
+      - deploy-production:
+          filters:
+            branches:
+              only: release
+          requires:
+            - push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ jobs:
       - run:
           name: Push
           command: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
-
   deploy-staging:
     docker:
       - image: artsy/hokusai
@@ -36,7 +35,6 @@ jobs:
       - run:
           name: Deploy
           command: hokusai staging deploy $CIRCLE_SHA1 --git-remote origin
-
   deploy-production:
     docker:
       - image: artsy/hokusai
@@ -59,6 +57,7 @@ workflows:
             branches:
               ignore:
                 - release
+                - staging
       - push:
           filters:
             branches:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ kaws
 
 Named after [the artist](https://artsy.net/artist/kaws), kaws is a backend service that powers [artsy.net](https://artsy.net) collection pages. What are collections you ask? A Collection is a prefiltered version of Artsy's [Collect](https://artsy.net/collect) page for marketing purposes.
 
+[![CircleCI](https://circleci.com/gh/artsy/kaws.svg?style=svg)](https://circleci.com/gh/artsy/kaws)
 * __State:__ in development
 * __Production:__ [k8s](https://kubernetes.artsy.net/#!/deployment/default/kaws-web?namespace=default)
 * __Staging:__  [http://kaws-staging.artsy.net](http://kaws-staging.artsy.net/playground) | [k8s](https://kubernetes-staging.artsy.net/#!/search?q=kaws&namespace=default)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 kaws
+===
 
-Named after [the artist](https://artsy.net/artist/kaws). Backend service that powers our collection pages.
-What are collections you ask? A Collection is a prefiltered version of the collect page for marketing purposes.
+Named after [the artist](https://artsy.net/artist/kaws), kaws is a backend service that powers [artsy.net](https://artsy.net) collection pages. What are collections you ask? A Collection is a prefiltered version of Artsy's [Collect](https://artsy.net/collect) page for marketing purposes.
 
+* __State:__ in development
+* __Production:__ [k8s](https://kubernetes.artsy.net/#!/deployment/default/kaws-web?namespace=default)
+* __Staging:__  [http://kaws-staging.artsy.net](http://kaws-staging.artsy.net/playground) | [k8s](https://kubernetes-staging.artsy.net/#!/search?q=kaws&namespace=default)
+* __Github:__ [https://github.com/artsy/positron/](https://github.com/artsy/kaws/)
+* __CI:__ [CircleCI](https://circleci.com/gh/artsy/kaws); merged PRs to artsy/kaws#master are automatically deployed to staging. PRs from `staging` to `release` are automatically deployed to production. [Start a deploy...](https://github.com/artsy/kaws/compare/release...staging?expand=1)
+* **Point People:** [@l2succes](https://github.com/l2succes)
 
 ## How do I work on this?
 
@@ -17,8 +23,3 @@ yarn install
 yarn jest
 ```
 
-## How do I deploy this?
-
-```sh
-yarn release
-```


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/GROW-934

- Adds `deploy-staging` and `deploy-production` steps to circle.yml
- Updates staging github branch when deploying to staging
- Adds some additional basic info to readme

Not sure if I need to manually create a staging and release branch, but will find out once this is merged.

Also, now that we are set up for circle deploys, do we still want the 'release-it' package? Noticed a mention about changelog, if we keep the package it would be great to get instructions on updating the changelog for the readme.