### PR TITLE
Initialize DataDog tracer before loading other modules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 NODE_ENV=development
 PORT=4000
 APP_NAME=kaws-staging
+DD_APM_ENABLED=false
 
 # Database auth
 MONGOHQ_URL=mongodb://localhost:27017/kaws

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,11 +4,13 @@
   "editor.tabSize": 2,
   "javascript.validate.enable": true,
   "files.exclude": {
-    "**/.git": true
+    "**/.git": true,
+    "**/build": false
   },
   "search.exclude": {
     "**/node_modules": true,
-    "**/graphql": true
+    "**/graphql": true,
+    "**/build": true
   },
   "tslint.autoFixOnSave": true,
   "editor.formatOnSave": true,

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,2 +1,0 @@
-# TS build files
-build

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,2 @@
+# TS build files
+build

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dump-schema": "ts-node scripts/dumpSchema.ts",
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "release": "release-it",
-    "start": "node -r build/index.js",
+    "start": "node build/index.js",
     "test": "jest",
     "type-check": "tsc --noEmit",
     "watch": "tsc --watch"
@@ -58,6 +58,7 @@
     "typeorm": "^0.2.7"
   },
   "devDependencies": {
+    "@types/dd-trace": "^0.6.1",
     "@types/jest": "^23.3.2",
     "@types/lodash": "^4.14.116",
     "@types/mongodb-uri": "^0.9.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,5 @@
-// tslint:disable:no-console
-
+import * as ddTracer from "dd-trace"
 import "dotenv/config"
-import "reflect-metadata"
-
-import ddTracer from "dd-trace"
-import { GraphQLServer, Options } from "graphql-yoga"
-import { parse } from "mongodb-uri"
-import * as morgan from "morgan"
-import { Connection, createConnection } from "typeorm"
-
-import { createSchema } from "./createSchema"
-import { entities } from "./Entities"
 
 const {
   DD_APM_ENABLED,
@@ -19,6 +8,44 @@ const {
   NODE_ENV,
   PORT,
 } = process.env
+
+// Setup DataDog before importing another modules,
+// so DataDog gets a chance to patch the integrations as per the documation.
+// https://github.com/DataDog/dd-trace-js/blob/f638dd66845806ed3ee06e8fbf32b0062b9d21d7/src/proxy.js#L33
+if (DD_APM_ENABLED) {
+  ddTracer.init({
+    hostname: DD_TRACE_AGENT_HOSTNAME,
+    service: "kaws",
+    plugins: false,
+    // TODO: figure out how to get the debugger working
+    // debug: true,
+    // logger: {
+    //   debug: console.log,
+    //   error: console.error,
+    // },
+  })
+  ddTracer.use("express", {
+    service: "kaws",
+    headers: ["User-Agent"],
+  })
+  ddTracer.use("graphql", {
+    service: "kaws.graphql",
+  })
+  ddTracer.use("http", {
+    service: `kaws.http-client`,
+  })
+}
+
+// tslint:disable:no-console
+import "reflect-metadata"
+
+import { GraphQLServer, Options } from "graphql-yoga"
+import { parse } from "mongodb-uri"
+import * as morgan from "morgan"
+import { Connection, createConnection } from "typeorm"
+
+import { createSchema } from "./createSchema"
+import { entities } from "./Entities"
 
 bootstrap()
 
@@ -65,25 +92,6 @@ async function bootstrap() {
 
     // Setup endpoints
     app.get("/health", (req, res) => res.status(200).end())
-
-    // Setup DataDog
-    if (DD_APM_ENABLED) {
-      ddTracer.init({
-        hostname: DD_TRACE_AGENT_HOSTNAME,
-        service: "kaws",
-        plugins: false,
-      })
-      ddTracer.use("express", {
-        service: "kaws",
-        headers: ["User-Agent"],
-      })
-      ddTracer.use("graphql", {
-        service: "kaws.graphql",
-      })
-      ddTracer.use("http", {
-        service: `kaws.http-client`,
-      })
-    }
 
     // Start the server
     server.start(serverOptions, ({ port, playground }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import * as ddTracer from "dd-trace"
 import "dotenv/config"
+
+import * as ddTracer from "dd-trace"
 
 const {
   DD_APM_ENABLED,

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,13 @@
   dependencies:
     "@types/express" "*"
 
+"@types/dd-trace@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@types/dd-trace/-/dd-trace-0.6.1.tgz#2795fb5b3ab23db9d7b776ba13e99ddca2564db3"
+  integrity sha512-P3i9fQFrq6CbxCD55xd9Qv4cZ9eASOnh3PzZwhaOhm/lfjFLmgAyLol+J5pefj/J/HSPAWT78tyXKNurP8rcGw==
+  dependencies:
+    opentracing ">=0.14.1"
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -1522,6 +1529,11 @@ class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
   integrity sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
 
 class-validator@>=0.9.1:
   version "0.9.1"
@@ -5407,6 +5419,11 @@ opentracing@0.14.1:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.1.tgz#40d278beea417660a35dd9d3ee76511ffa911dcd"
   integrity sha1-QNJ4vupBdmCjXdnT7nZRH/qRHc0=
+
+opentracing@>=0.14.1:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.3.tgz#23e3ad029fa66a653926adbe57e834469f8550aa"
+  integrity sha1-I+OtAp+mamU5Jq2+V+g0Rp+FUKo=
 
 optimist@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Related to: https://artsyproduct.atlassian.net/browse/GROW-943

Per the [documentation](https://github.com/DataDog/dd-trace-js/blob/f638dd66845806ed3ee06e8fbf32b0062b9d21d7/src/proxy.js#L33), we need to make sure we initialize the tracer before loading other libraries in order to correctly setup logging to DataDog.

A todo item we may want to circle back to is ensuring that we can verify what will be sent to DataDog by passing `debug: true` in the options.  For now, we were able to work around this by setting a breakpoint in the [writer.js](https://github.com/DataDog/dd-trace-js/blob/f638dd66845806ed3ee06e8fbf32b0062b9d21d7/src/writer.js#L68) file within the dd-trace library.