### PR TITLE
Update sitemap as part of bootstrap-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "bootstrap-data": "ts-node scripts/bootstrapOrUpdate.ts",
+    "bootstrap-data": "ts-node scripts/bootstrapOrUpdate.ts && yarn update-sitemap",
     "build": "tsc",
     "dev": "node --inspect -r ts-node/register src/index.ts",
     "dump-schema": "ts-node scripts/dumpSchema.ts",


### PR DESCRIPTION
We seem to have fotgotten to run `yarn update-sitemap` after a batch update so let's just run it as part of `yarn bootstrap-data` so we never forget to run it (or do forget about it and not worry about it).

#trivial