### PR TITLE
Avoid group mongodb function since it's not supported on lower-end Atlas clusters

### DIFF
--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -16,27 +16,12 @@ export class CollectionsResolver {
   // TODO: should return a connection
   @Query(returns => [CollectionCategory])
   async categories(): Promise<CollectionCategory[]> {
-    const data = await this.repository.group(
-      { category: 1 },
-      { category: { $exists: true } },
-      {},
-      (curr, result) => {
-        if (!result.collections) {
-          result.collections = [curr]
-        } else {
-          result.collections.push(curr)
-        }
-      },
-      result => result,
-      true
-    )
-
-    return data.map(({ category, collections }) => ({
+    const categories = await this.repository.distinct("category", {
+      category: { $ne: null },
+    })
+    return categories.map(category => ({
       name: category,
-      collections: collections.map(col => ({
-        ...col,
-        id: col._id,
-      })),
+      collections: this.repository.find({ category }),
     }))
   }
 

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -9,19 +9,13 @@ const mockedGetMongoRepository = getMongoRepository as jest.Mock
 
 beforeEach(() => {
   mockedGetMongoRepository.mockReturnValue({
-    find: () => mockCollectionRepository,
+    find: () => Promise.resolve(mockCollectionRepository),
     findOne: ({ slug }) =>
       mockCollectionRepository.find(
         (collection: Collection) => collection.slug === slug
       ),
-    group: (_keys, _condition, _initial, reduce, _finalize, _command) => {
-      const result = {
-        category: mockCollectionRepository[0].category,
-      }
-      mockCollectionRepository.map(collection => {
-        return reduce(collection, result)
-      })
-      return [result]
+    distinct: _key => {
+      return ["Collectible Sculptures"]
     },
   })
 })


### PR DESCRIPTION
After migrating Kaws's staging database (as part of PLATFORM-1079), we noticed staging's `/collections` page failing with a server-side error. The underlying graphql query was failing with `Error: CMD_NOT_ALLOWED: group`.

I couldn't find clear documentation of this in Atlas's [list of unsupported commands](https://docs.atlas.mongodb.com/reference/free-shared-limitations/#atlas-free-tier), but maybe `group` actually relies on the aggregation framework in v4. This switches the query to use a `distinct`, with additional queries to load the collections for each category.