### PR TITLE
Unchain update-database and update-sitemap in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "update-database": "ts-node scripts/bootstrapOrUpdate.ts && yarn update-sitemap",
+    "update-database": "ts-node scripts/bootstrapOrUpdate.ts",
     "build": "tsc",
     "dev": "node --inspect -r ts-node/register src/index.ts",
     "dump-schema": "ts-node scripts/dumpSchema.ts",


### PR DESCRIPTION
Removed the call to `yarn update-sitemap` from the definition of `update-database` so that command line arguments could be passed to the script that handles `update-database`. This is necessary for CSV files to be passed to that script. Otherwise, any command line arguments are passed on to the last script in the chain.

@yuki24 I found [this commit](https://github.com/artsy/kaws/commit/9dcf26a5ffa3612eed0fb8576e43ada340dcccfb#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) from last month. What was the context for this change?