### PR TITLE
@mzikherman => [Search] Add `visible_to_public` and `search_boost`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Master
 
+- Enable text search - [@mzikherman]
 - Initial setup - [@l2succes]
 - Sets up TypeORM + mongodb - [@l2succes]
 - Light project cleanup - [@damassi]

--- a/src/utils/__tests__/indexForSearch.test.ts
+++ b/src/utils/__tests__/indexForSearch.test.ts
@@ -68,6 +68,8 @@ describe("indexForSearch", () => {
     expect(firstCollection.body.featured_names).toBe("Contemporary")
     expect(firstCollection.body.alternate_names).toBe("Cats, Awesome, Art")
     expect(firstCollection.body.slug).toBe("cat-pictures")
+    expect(firstCollection.body.visible_to_public).toBe(true)
+    expect(firstCollection.body.search_boost).toBe(1000)
     const secondCollection = SearchClientMock.index.mock.calls[1][0]
     expect(secondCollection.index).toBe("marketing_collections_development")
     expect(secondCollection.type).toBe("marketing_collection")
@@ -76,5 +78,7 @@ describe("indexForSearch", () => {
     expect(secondCollection.body.featured_names).toBe("Abstract")
     expect(secondCollection.body.alternate_names).toBe("Dogs, Also Cool")
     expect(secondCollection.body.slug).toBe("dog-pictures")
+    expect(secondCollection.body.visible_to_public).toBe(true)
+    expect(secondCollection.body.search_boost).toBe(1000)
   })
 })

--- a/src/utils/indexForSearch.ts
+++ b/src/utils/indexForSearch.ts
@@ -22,17 +22,28 @@ export const indexForSearch = async () => {
       const collections = await repository.find()
       for (const collection of collections) {
         // Schema assumes fields named `name`, `featured_names`, `alternate_names`
-        // to be present for search.
+        // to be present for text search through those fields.
+        // Additionally, `visible_to_public` and `search_boost` are required for
+        // proper surfacing of results.
         const name = collection.title
         const alternate_names = collection.query.keyword
         const featured_names = collection.category
         const slug = collection.slug
+        const visible_to_public = true
+        const search_boost = 1000
 
         await search.client.index({
           index: search.index,
           type: "marketing_collection",
           id: collection.id.toString(),
-          body: { name, alternate_names, featured_names, slug },
+          body: {
+            name,
+            alternate_names,
+            featured_names,
+            slug,
+            visible_to_public,
+            search_boost,
+          },
         })
 
         console.log("Successfully updated: ", collection.title)


### PR DESCRIPTION
These fields are needed for proper surfacing of results. `visible_to_public` can be updated to reflect 'unpublished' collections (if that's a thing), and `search_boost` can be modified to be exp decay of collections 'created/published at' (to weight more recent collections)- if we want!