### PR TITLE
@l2succes => [Collections] Allow querying for collections by artist id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Master
 
+- Return collections for an artist - [@mzikherman]
 - Enable text search - [@mzikherman]
 - Initial setup - [@l2succes]
 - Sets up TypeORM + mongodb - [@l2succes]

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -71,7 +71,7 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections: [Collection!]!
+  collections(artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -9,8 +9,16 @@ export class CollectionsResolver {
 
   // TODO: should return a connection
   @Query(returns => [Collection])
-  async collections(): Promise<Collection[]> {
-    return await this.repository.find()
+  async collections(
+    @Arg("artistID", { nullable: true }) artistID: string
+  ): Promise<Collection[]> {
+    if (artistID) {
+      return await this.repository.find({
+        where: { "query.artist_ids": { $in: [artistID] } },
+      })
+    } else {
+      return await this.repository.find()
+    }
   }
 
   // TODO: should return a connection

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -74,7 +74,7 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections: [Collection!]!
+  collections(artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }


### PR DESCRIPTION
Tested locally against staging, seems to work!

I skipped tests since they wouldn't add anything in this case: https://github.com/artsy/kaws/blob/9834452bc011903ad90245467d54f068c131b0ff/src/Resolvers/__tests__/collection_resolvers.test.ts#L11-L12 , everything is stubbed. Although, a spec that at least checks that the schema accepts a query like `collections(artistID: "...")` might be useful. It wouldn't really exercise whether the lookup functionally works, but it would assert something about the shape of the schema.