### PR TITLE
@pepopowitz => Support `size` for querying collections

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -77,7 +77,11 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections(showOnEditorial: Boolean, artistID: String): [Collection!]!
+  collections(
+    size: Int
+    showOnEditorial: Boolean
+    artistID: String
+  ): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -1,4 +1,4 @@
-import { Arg, Query, Resolver } from "type-graphql"
+import { Arg, Int, Query, Resolver } from "type-graphql"
 import { getMongoRepository } from "typeorm"
 import { Collection } from "../Entities/Collection"
 import { CollectionCategory } from "../Entities/CollectionCategory"
@@ -10,7 +10,8 @@ export class CollectionsResolver {
   @Query(returns => [Collection])
   async collections(
     @Arg("artistID", { nullable: true }) artistID: string,
-    @Arg("showOnEditorial", { nullable: true }) showOnEditorial: boolean
+    @Arg("showOnEditorial", { nullable: true }) showOnEditorial: boolean,
+    @Arg("size", () => Int, { nullable: true }) size: number
   ): Promise<Collection[]> {
     const hasArguments =
       [].filter.call(arguments, arg => arg !== undefined).length > 0
@@ -21,6 +22,9 @@ export class CollectionsResolver {
     }
     if (artistID) {
       query.where["query.artist_ids"] = { $in: [artistID] }
+    }
+    if (size) {
+      query.take = size
     }
     return await this.repository.find(query)
   }

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -142,6 +142,24 @@ describe("Collections", () => {
         expect((data as any).collections.length).toBeTruthy()
       })
     })
+
+    it("can restrict via size", () => {
+      const query = `
+        {
+          collections(size: 1) {
+            id
+          }
+        }
+      `
+
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(find).toBeCalledWith({
+          take: 1,
+          where: {},
+        })
+        expect((data as any).collections.length).toBeTruthy()
+      })
+    })
   })
 })
 

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -80,7 +80,7 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections(showOnEditorial: Boolean, artistID: String): [Collection!]!
+  collections(size: Int, showOnEditorial: Boolean, artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }


### PR DESCRIPTION
As discussed, this ~~adds `image_url` to the search index and~~ supports passing in a size param.

Since this gets stitched into the Metaphysics schema and this changes the KAWS schema, there's a small MP PR needed to update the stored schema there, as well as pass this arg along.