### PR TITLE
add randomize to collections args query

### DIFF
--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from "lodash"
 import { Arg, Int, Query, Resolver } from "type-graphql"
 import { getMongoRepository } from "typeorm"
 import { Collection } from "../Entities/Collection"
@@ -11,7 +12,8 @@ export class CollectionsResolver {
   async collections(
     @Arg("artistID", { nullable: true }) artistID: string,
     @Arg("showOnEditorial", { nullable: true }) showOnEditorial: boolean,
-    @Arg("size", () => Int, { nullable: true }) size: number
+    @Arg("size", () => Int, { nullable: true }) size: number,
+    @Arg("randomize", { nullable: true }) randomize: boolean
   ): Promise<Collection[]> {
     const hasArguments =
       [].filter.call(arguments, arg => arg !== undefined).length > 0
@@ -23,10 +25,27 @@ export class CollectionsResolver {
     if (artistID) {
       query.where["query.artist_ids"] = { $in: [artistID] }
     }
-    if (size) {
+    if (!randomize && size) {
       query.take = size
     }
-    return await this.repository.find(query)
+
+    if (randomize) {
+      const aggregatePipeline: any = []
+      if (!isEmpty(query.where)) {
+        aggregatePipeline.push({ $match: query })
+      }
+      const randomizeBy = size ? size : 4
+      aggregatePipeline.push({ $sample: { size: randomizeBy } })
+
+      const data = await this.repository.aggregate(aggregatePipeline).toArray()
+
+      data.forEach(item => (item.id = item._id))
+
+      return data
+    } else {
+      const data = await this.repository.find(query)
+      return data
+    }
   }
 
   // TODO: should return a connection

--- a/src/Resolvers/__tests__/fixtures/data.ts
+++ b/src/Resolvers/__tests__/fixtures/data.ts
@@ -4,6 +4,7 @@ import { Collection } from "../../../Entities/Collection"
 export const mockCollectionRepository = plainToClass(Collection, [
   {
     id: 1,
+    _id: 1,
     slug: "kaws-companions",
     title: "KAWS: Companions",
     category: "Collectible Sculptures",
@@ -19,6 +20,7 @@ export const mockCollectionRepository = plainToClass(Collection, [
   },
   {
     id: 2,
+    _id: 2,
     title: "Big Artists, Small Sculptures",
     category: "Collectible Sculptures",
     description:
@@ -31,6 +33,22 @@ export const mockCollectionRepository = plainToClass(Collection, [
       gene_id: null,
     },
     show_on_editorial: true,
+    price_guidance: 1000,
+  },
+  {
+    id: 3,
+    _id: 3,
+    title: "Jasper Johns: Flags",
+    category: "Pop Art",
+    description:
+      '<p>In 1954, two years after being discharged from the United States Army, the 24-year-old <a href="https://www.artsy.net/artist/jasper-johns">Jasper Johns</a> had a vivid dream of the American flag.</p>',
+    slug: "jasper-johns-flags",
+    headerImage: "http://files.artsy.net/images/jasperjohnsflag.png",
+    query: {
+      id: null,
+      tag_id: null,
+    },
+    show_on_editorial: false,
     price_guidance: 1000,
   },
 ])


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-1145

This PR adds a new `randomize` argument to the collections query that supports pulling collections at random from KAWS. This is needed to prevent the new [collections rails component](https://github.com/artsy/reaction/tree/master/src/Components/CollectionsRail) from displaying the same 4 collections.

The query is to be used like:
```
{
  collections(size: 4, randomize: true) {
    ...
  }
}
```

Follow up work needed is to add the new argument to the query in reaction.