### PR TITLE
update snapshot test

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -78,6 +78,7 @@ scalar DateTime
 
 type Query {
   collections(
+    randomize: Boolean
     size: Int
     showOnEditorial: Boolean
     artistID: String

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -80,7 +80,7 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections(size: Int, showOnEditorial: Boolean, artistID: String): [Collection!]!
+  collections(randomize: Boolean, size: Int, showOnEditorial: Boolean, artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }


### PR DESCRIPTION
Related to https://github.com/artsy/kaws/pull/70

This updates the `_schema.graphql` file and associated snapshot test. I missed this step in the [initial PR](https://github.com/artsy/kaws/pull/70) but I'm pretty surprised that the CI build didn't catch this. The [PR's build](https://circleci.com/gh/artsy/kaws/298) seemed to have passed...? I only caught it because I was trying to QA in staging and seeing errors and then noticed the build was failing. Then I saw in the docs that I needed to run the `dump-schema` command.

Are there any additional steps that you can think of that I need to do? I'm also preparing a metaphysics PR with the up-to-date `kaws.graphql` file. I'm getting an `"Response not successful: Received status code 400"` error but I'm assuming that's because this is not yet merge?