### PR TITLE
pass the correct query format

### DIFF
--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -32,7 +32,7 @@ export class CollectionsResolver {
     if (randomize) {
       const aggregatePipeline: any = []
       if (!isEmpty(query.where)) {
-        aggregatePipeline.push({ $match: query })
+        aggregatePipeline.push({ $match: query.where })
       }
       const randomizeBy = size ? size : 4
       aggregatePipeline.push({ $sample: { size: randomizeBy } })

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -208,7 +208,7 @@ describe("Collections", () => {
 
     return runQuery(query, {}, createMockSchema).then(data => {
       expect(mockAggregate).toBeCalledWith([
-        { $match: { where: { show_on_editorial: true } } },
+        { $match: { show_on_editorial: true } },
         { $sample: { size: 2 } },
       ])
     })


### PR DESCRIPTION
Fixes QA issues related to [GROW-1145](https://artsyproduct.atlassian.net/browse/GROW-1145)

As I was QA'ing the new `randomize` arg, I noticed that when it was passed with other arguments (i.e. `showOnEditorial: true`) we were returning an empty array. This was because I was passing the incorrect query format. I was previously passing `{ where: { show_on_editorial: true } }` to the match property when it should be ` { show_on_editorial: true }`. This PR fixes that. The work in Kaws related to randomize should be legit now.