### PR TITLE
use randomizationSeed instead of randomize boolean

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -78,7 +78,7 @@ scalar DateTime
 
 type Query {
   collections(
-    randomize: Boolean
+    randomizationSeed: String
     size: Int
     showOnEditorial: Boolean
     artistID: String

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -13,7 +13,7 @@ export class CollectionsResolver {
     @Arg("artistID", { nullable: true }) artistID: string,
     @Arg("showOnEditorial", { nullable: true }) showOnEditorial: boolean,
     @Arg("size", () => Int, { nullable: true }) size: number,
-    @Arg("randomize", { nullable: true }) randomize: boolean
+    @Arg("randomizationSeed", { nullable: true }) randomizationSeed: string
   ): Promise<Collection[]> {
     const hasArguments =
       [].filter.call(arguments, arg => arg !== undefined).length > 0
@@ -25,11 +25,11 @@ export class CollectionsResolver {
     if (artistID) {
       query.where["query.artist_ids"] = { $in: [artistID] }
     }
-    if (!randomize && size) {
+    if (!randomizationSeed && size) {
       query.take = size
     }
 
-    if (randomize) {
+    if (randomizationSeed) {
       const aggregatePipeline: any = []
       if (!isEmpty(query.where)) {
         aggregatePipeline.push({ $match: query.where })

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -185,7 +185,7 @@ describe("Collections", () => {
     it("can return collections in random order via randomize", () => {
       const query = `
         {
-          collections(randomize: true) {
+          collections(randomizationSeed: "123") {
             id
           }
         }
@@ -200,7 +200,7 @@ describe("Collections", () => {
   it("can return collections in random order via randomize with query", () => {
     const query = `
       {
-        collections(randomize: true, size: 2, showOnEditorial: true) {
+        collections(randomizationSeed: "1234", size: 2, showOnEditorial: true) {
           id
         }
       }

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -80,7 +80,7 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections(randomize: Boolean, size: Int, showOnEditorial: Boolean, artistID: String): [Collection!]!
+  collections(randomizationSeed: String, size: Int, showOnEditorial: Boolean, artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }


### PR DESCRIPTION
This changes support for randomization to use a `randomizationSeed` that passes a unique string. This is to address the issue of the collections rail component getting updated with the same collection data despite being on different articles. This is caused because the way relay handles rendering component when the same parameters are passed.

ToDo:

- [x] Create a PR in metaphysics with schema changes.
- [x] Create a PR in reaction to sync the schema and use the updated parameter.