### PR TITLE
Use slugify to sanitize slug

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-fetch": "^2.3.0",
     "reflect-metadata": "^0.1.12",
     "sailthru-client": "^3.0.2",
-    "slugify": "^1.3.1",
+    "slugify": "^1.3.4",
     "type-graphql": "^0.14.0",
     "typeorm": "^0.2.7"
   },

--- a/src/utils/__tests__/convertCSVToJSON.test.ts
+++ b/src/utils/__tests__/convertCSVToJSON.test.ts
@@ -58,11 +58,16 @@ describe("sanitizeSlug", () => {
     expect(cleanedSlug).toBe("alexander-calder-lithographs")
   })
 
-  it("Removes punctuation from slugs", () => {
+  it("Converts symbols to text", () => {
     const cleanedSlug = sanitizeSlug(
       ".,&:/#!$%^*;{}=_`’~()alexander-calder-lithographs/"
     )
-    expect(cleanedSlug).toBe("alexander-calder-lithographs")
+    expect(cleanedSlug).toBe("anddollarpercentalexander-calder-lithographs")
+  })
+
+  it("Removes special characters", () => {
+    const cleanedSlug = sanitizeSlug("salvador-dalí-casanova")
+    expect(cleanedSlug).toBe("salvador-dali-casanova")
   })
 
   it("Sets casing to lowercase", () => {

--- a/src/utils/convertCSVToJSON.ts
+++ b/src/utils/convertCSVToJSON.ts
@@ -1,5 +1,6 @@
 import * as csv from "csv-parser"
 import * as fs from "fs"
+import slugify from "slugify"
 import { Collection } from "../Entities/Collection"
 
 export const convertCSVToJSON: (string) => Promise<Collection[]> = (
@@ -66,8 +67,10 @@ export const convertCSVToJSON: (string) => Promise<Collection[]> = (
 }
 
 export const sanitizeSlug = (slug: string) => {
-  const cleanedSlug = slug
-    .replace(/ /g, "")
-    .replace(/[.,&:\/#!$%\^\*;{}=_`’~()]/g, "")
-  return cleanedSlug.toLowerCase()
+  const cleanedSlug = slugify(slug, {
+    remove: /[.'",&:\/#!$%\^\*;{}=_`’~()]/g,
+    lower: true,
+  })
+
+  return cleanedSlug
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6985,10 +6985,10 @@ slice-ansi@0.0.4:
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
   integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
-slugify@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.1.tgz#f572127e8535329fbc6c1edb74ab856b61ad7de2"
-  integrity sha512-6BwyhjF5tG5P8s+0DPNyJmBSBePG6iMyhjvIW5zGdA3tFik9PtK+yNkZgTeiroCRGZYgkHftFA62tGVK1EI9Kw==
+slugify@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.3.4.tgz#78d2792d7222b55cd9fc81fa018df99af779efeb"
+  integrity sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw==
 
 snapdragon-node@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
Removes manual regex in favor of `slugify` package to sanitize slugs when importing.