### PR TITLE
Update Hokusai configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,13 @@ jobs:
       - checkout
       - run:
           name: Configure hokusai
-          command: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
+          command:
+            hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel
+            --s3-key k8s/config --platform linux
       - run:
           name: Update staging branch
-          command: git push git@github.com:artsy/kaws.git $CIRCLE_SHA1:staging --force
+          command:
+            git push git@github.com:artsy/kaws.git $CIRCLE_SHA1:staging --force
       - run:
           name: Deploy staging assets
           command: hokusai staging deploy $CIRCLE_SHA1
@@ -43,7 +46,9 @@ jobs:
       - checkout
       - run:
           name: Configure hokusai
-          command: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
+          command:
+            hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel
+            --s3-key k8s/config --platform linux
       - run:
           name: Deploy production assets
           command: hokusai production deploy $CIRCLE_SHA1 --git-remote origin

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,1 +1,2 @@
 project-name: kaws
+hokusai-required-version: ">=0.5.3"

--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,4 +1,1 @@
----
-aws-account-id: '585031190124'
-aws-ecr-region: us-east-1
 project-name: kaws

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,5 +1,4 @@
----
-version: '2'
+version: "2"
 services:
   kaws:
     extends:
@@ -7,3 +6,10 @@ services:
       service: kaws
     ports:
       - 3000:3000
+    environment:
+      - MONGOHQ_URL=mongodb://kaws-mongodb:27017/kaws
+  kaws-mongodb:
+    image: mongo:4.0
+    ports:
+      - "27017:27017"
+    command: ["--storageEngine=mmapv1", "--quiet", "--nojournal"]

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -74,7 +74,7 @@ spec:
     kind: Deployment
     name: kaws-web
   minReplicas: 2
-  maxReplicas: 4
+  maxReplicas: 6
   targetCPUUtilizationPercentage: 70
 
 ---

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -4,7 +4,6 @@ metadata:
   name: kaws-web
   namespace: default
 spec:
-  replicas: 2
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -47,7 +46,11 @@ spec:
                   value: https
             initialDelaySeconds: 5
             periodSeconds: 5
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -57,6 +60,21 @@ spec:
                     operator: In
                     values:
                       - foreground
+
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kaws-web
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: kaws-web
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 70
 
 ---
 apiVersion: v1

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -44,8 +44,9 @@ spec:
               httpHeaders:
                 - name: X-FORWARDED-PROTO
                   value: https
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -4,7 +4,6 @@ metadata:
   name: kaws-web
   namespace: default
 spec:
-  replicas: 1
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -47,7 +46,11 @@ spec:
                   value: https
             initialDelaySeconds: 5
             periodSeconds: 5
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -57,6 +60,21 @@ spec:
                     operator: In
                     values:
                       - foreground
+
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kaws-web
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: kaws-web
+  minReplicas: 1
+  maxReplicas: 2
+  targetCPUUtilizationPercentage: 70
 
 ---
 apiVersion: v1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -44,8 +44,9 @@ spec:
               httpHeaders:
                 - name: X-FORWARDED-PROTO
                   value: https
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:


### PR DESCRIPTION
These changes have not yet been applied to production (though they are active in staging now). This PR addresses all items flagged in https://artsyproduct.atlassian.net/browse/PLATFORM-1151, also tracked via https://artsyproduct.atlassian.net/browse/GROW-1156

- Use kubectl version 1.10.7
- Pin node runtime version and use Alpine build
- Set up `deploy` user
- Use Dumb-Init as `ENTRYPOINT`
- Use npm rather than script to install yarn
- Run `yarn cache clean` inline with `yarn install`
- Update hokusai required version
- Add mongo to hokusai dev build
- Use autoscaling for replicas
- Use `ClusterFirst` for dns
- Update heath check endpoint delay/period/timeout seconds
