### PR TITLE
Automate pulling CSV using Google sheets API

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -5,9 +5,12 @@ services:
       file: build.yml
       service: kaws
     ports:
-      - 3000:3000
+      - 4000:4000
+    env_file: ../.env
     environment:
       - MONGOHQ_URL=mongodb://kaws-mongodb:27017/kaws
+    depends_on:
+      - kaws-mongodb
   kaws-mongodb:
     image: mongo:4.0
     ports:

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@sentry/node": "^4.6.4",
     "aws-sdk": "^2.377.0",
+    "body-parser": "^1.18.3",
     "class-transformer": "^0.1.9",
     "csv-parser": "^2.1.0",
     "dd-trace": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "csv-parser": "^2.1.0",
     "dd-trace": "^0.6.0",
     "elasticsearch": "^15.3.1",
+    "googleapis": "27",
     "graphql-yoga": "^1.16.2",
     "lodash": "^4.17.11",
     "mongodb": "~3.0.8",

--- a/scripts/bootstrapOrUpdate.ts
+++ b/scripts/bootstrapOrUpdate.ts
@@ -1,9 +1,7 @@
 import "dotenv/config"
 
-import { databaseURL } from "../src/config/database"
-
-import { MongoClient } from "mongodb"
 import { convertCSVToJSON } from "../src/utils/convertCSVToJSON"
+import { updateDatabase } from "../src/utils/updateDatabase"
 
 const csvFile = process.argv[2]
 
@@ -15,28 +13,11 @@ const csvFile = process.argv[2]
  */
 export async function bootstrapOrUpdate(path: string) {
   const data = await convertCSVToJSON(path)
-  const connection = await MongoClient.connect(databaseURL!)
-  const database = connection.db()
-  const collection = database.collection("collection")
-
   try {
-    if (connection.isConnected) {
-      for (const entry of data) {
-        await collection.update({ slug: entry.slug }, entry, { upsert: true })
-        console.log("Successfully updated: ", entry.slug, entry.title)
-      }
-
-      console.log("Successfully updated collections database")
-      connection.close()
-    }
+    updateDatabase(data)
     process.exit(0)
-  } catch (error) {
-    console.error("[kaws] Error bootstrapping data:", error)
+  } catch (e) {
     process.exit(1)
-  } finally {
-    /* tslint:disable:no-unused-expression */
-    connection && connection.close()
-    /* tslint:enable:no-unused-expression */
   }
 }
 

--- a/src/Routes/GSheetImport.ts
+++ b/src/Routes/GSheetImport.ts
@@ -1,0 +1,66 @@
+import * as bodyParser from "body-parser"
+import * as express from "express"
+import { gSheetDataFetcher } from "../utils/gSheetDataFetcher"
+import { sanitizeRow } from "../utils/sanitizeRow"
+import { updateDatabase } from "../utils/updateDatabase"
+
+const app = express()
+
+app.use(bodyParser.json())
+
+export const upload = async (
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+) => {
+  const { spreadSheetID, sheetName } = req.body
+
+  if (!spreadSheetID || !sheetName) {
+    return res
+      .status(500)
+      .send("A valid spreadSheetID and sheetName is required")
+  }
+
+  const data: object[] = await gSheetDataFetcher(spreadSheetID, sheetName)
+
+  const rows = data.slice(1).map((row: string[]) => {
+    const [
+      title,
+      slug,
+      category,
+      description,
+      headerImage,
+      credit,
+      artist_ids,
+      gene_ids,
+      tag_id,
+      keyword,
+      price_guidance,
+      show_on_editorial,
+      is_featured_artist_content,
+    ] = row
+
+    return sanitizeRow({
+      title,
+      slug,
+      category,
+      description,
+      headerImage,
+      credit,
+      artist_ids,
+      gene_ids,
+      tag_id,
+      keyword,
+      price_guidance,
+      show_on_editorial,
+      is_featured_artist_content,
+    })
+  })
+  updateDatabase(rows)
+
+  res.send(200)
+}
+
+app.post("/upload", upload)
+
+export default app

--- a/src/Routes/__tests__/GSheetImport.test.ts
+++ b/src/Routes/__tests__/GSheetImport.test.ts
@@ -1,0 +1,162 @@
+import { updateDatabase } from "../../utils/updateDatabase"
+import { upload } from "../GSheetImport"
+
+jest.mock("../../utils/gSheetDataFetcher", () => ({
+  gSheetDataFetcher: () => {
+    return rows
+  },
+}))
+
+jest.mock("../../utils/updateDatabase")
+
+describe("GSheetImport", () => {
+  let req: any
+  let res: any
+  let next: any
+
+  describe("#upload", () => {
+    beforeEach(() => {
+      req = {
+        path: "/",
+        query: {},
+        body: {},
+      }
+      res = {
+        status: jest.fn(() => res),
+        send: jest.fn(),
+      }
+      next = jest.fn()
+    })
+
+    it("Returns an error if spreadSheetID and sheetName is not set", async () => {
+      await upload(req, res, next)
+      expect(res.status).toBeCalledWith(500)
+      expect(res.send).toBeCalledWith(
+        "A valid spreadSheetID and sheetName is required"
+      )
+    })
+
+    it("Calls updateDatabase with downloaded rows data", async () => {
+      req.body = {
+        spreadSheetID: "123",
+        sheetName: "'All'",
+      }
+
+      await upload(req, res, next)
+      expect(updateDatabase).toBeCalledWith([
+        {
+          title: "Andy Warhol: Superman",
+          slug: "andy-warhol-superman",
+          category: "Pop Art",
+          description:
+            '<p>At eight years old, <a href="https://www.artsy.net/artist/andy-warhol">Andy Warhol</a> found a new idol: Superman. Diagnosed with an autoimmune disease, the young artist was bedridden for months after episodes of involuntary shaking led to bullying at school. At home, Warhol escaped into the world of comic books, especially the tale of Clark Kent. As an insecure young boy, Warhol found hope in Kent’s transformation from underdog to superhero. Decades later, he created his own rendition of Superman, portraying the character flying through the sky as part of his “<a href="https://www.artsy.net/collection/andy-warhol-myths">Myths</a>” portfolio. Warhol’s silkscreen <i>Superman</i> (1981) reached a new auction record in 2017, selling for over $200,000 at Phillips. But this isn’t the only Warhol motif inspired by his childhood illness—while bedridden, Warhol’s mother also fed him lots of <a href="https://www.artsy.net/collection/andy-warhol-campbells-soup-can">Campbell’s Soup</a>.</p>',
+          headerImage: "http://files.artsy.net/images/andywarholsuperman.png",
+          credit:
+            "<p>&copy; Andy Warhol / Artist Rights Society (ARS), New York, NY.</p>",
+          price_guidance: null,
+          show_on_editorial: false,
+          is_featured_artist_content: false,
+          query: {
+            artist_ids: ["4d8b92b34eb68a1b2c0003f4"],
+            gene_ids: [],
+            tag_id: "",
+            keyword: "Superman",
+          },
+        },
+        {
+          title: "Anish Kapoor: Etchings",
+          slug: "anish-kapoor-etchings",
+          category: "Contemporary",
+          description:
+            '<p>In the late 1980s, <a href="https://www.artsy.net/artist/anish-kapoor">Anish Kapoor</a> began experimenting with printmaking, turning to the etching technique to portray abstract voids on handmade paper. In a process that can last several months and dozens of trips to the studio, Kapoor uses several techniques to create a finished etching, layering his freely etched prints with additional color deposits from aquatint plates, spit bite plates, or acid washing. The end product calls to mind TV static, primordial cells, or cosmic dust—familiar yet intangible, seeming to morph into new forms before one’s eyes. “The void is not silent,” he <a href="http://anishkapoor.com/185/making-emptiness-by-homi-k-bhabha">says</a>. “I have always thought of it more and more as a transitional space, an in-between space.” Ranging from dark abstractions to bright bursts of color, Kapoor’s most celebrated series of etchings include <i>15 Etchings</i> (1996), <i>Blackness from her Womb</i> (2000), <i>12 Etchings</i> (2004), <i>Shadow</i> (2007–12), and <i>Fold</i> (2014–16).</p>',
+          headerImage: "http://files.artsy.net/images/anishkapooretchings.png",
+          credit:
+            "<p>&copy; Anish Kapoor / Artist Rights Society (ARS), New York, NY.</p>",
+          price_guidance: null,
+          show_on_editorial: false,
+          is_featured_artist_content: false,
+          query: {
+            artist_ids: ["4de528068236f6000100070b"],
+            gene_ids: ["etching-slash-engraving"],
+          },
+        },
+        {
+          title: "Ansel Adams: Yosemite",
+          slug: "ansel-adams-yosemite",
+          category: "Photography",
+          description: "",
+          headerImage: "http://files.artsy.net/images/anseladamsyosemite.png",
+          credit:
+            "<p>Ansel Adams, <i>El Capitan, Sunrise, Yosemite National Park</i>, 1956. Courtesy of Robert Klein Gallery.</p>",
+          price_guidance: null,
+          show_on_editorial: false,
+          is_featured_artist_content: true,
+          query: {
+            artist_ids: ["4e677d4ff8597e00010072e0"],
+            gene_ids: [],
+            tag_id: "",
+            keyword:
+              "Yosemite, El Capitan, Half Dome, Sentinel Dome, fern spring, Half Dome, nevada falls, Tuolomne Meadows",
+          },
+        },
+      ])
+
+      expect(res.send).toBeCalledWith(200)
+    })
+  })
+})
+
+const rows = [
+  [
+    "title",
+    "slug",
+    "category",
+    "description",
+    "headerImage",
+    "credit",
+    "artist_ids",
+    "gene_ids",
+    "tag_id",
+    "keyword",
+    "price_guidance",
+    "show_on_editorial",
+    "is_featured_artist_content",
+  ],
+  [
+    "Andy Warhol: Superman",
+    "andy-warhol-superman",
+    "Pop Art",
+    '<p>At eight years old, <a href="https://www.artsy.net/artist/andy-warhol">Andy Warhol</a> found a new idol: Superman. Diagnosed with an autoimmune disease, the young artist was bedridden for months after episodes of involuntary shaking led to bullying at school. At home, Warhol escaped into the world of comic books, especially the tale of Clark Kent. As an insecure young boy, Warhol found hope in Kent’s transformation from underdog to superhero. Decades later, he created his own rendition of Superman, portraying the character flying through the sky as part of his “<a href="https://www.artsy.net/collection/andy-warhol-myths">Myths</a>” portfolio. Warhol’s silkscreen <i>Superman</i> (1981) reached a new auction record in 2017, selling for over $200,000 at Phillips. But this isn’t the only Warhol motif inspired by his childhood illness—while bedridden, Warhol’s mother also fed him lots of <a href="https://www.artsy.net/collection/andy-warhol-campbells-soup-can">Campbell’s Soup</a>.</p>',
+    "http://files.artsy.net/images/andywarholsuperman.png",
+    "<p>&copy; Andy Warhol / Artist Rights Society (ARS), New York, NY.</p>",
+    "4d8b92b34eb68a1b2c0003f4",
+    "",
+    "",
+    "Superman",
+  ],
+  [
+    "Anish Kapoor: Etchings",
+    "anish-kapoor-etchings",
+    "Contemporary",
+    '<p>In the late 1980s, <a href="https://www.artsy.net/artist/anish-kapoor">Anish Kapoor</a> began experimenting with printmaking, turning to the etching technique to portray abstract voids on handmade paper. In a process that can last several months and dozens of trips to the studio, Kapoor uses several techniques to create a finished etching, layering his freely etched prints with additional color deposits from aquatint plates, spit bite plates, or acid washing. The end product calls to mind TV static, primordial cells, or cosmic dust—familiar yet intangible, seeming to morph into new forms before one’s eyes. “The void is not silent,” he <a href="http://anishkapoor.com/185/making-emptiness-by-homi-k-bhabha">says</a>. “I have always thought of it more and more as a transitional space, an in-between space.” Ranging from dark abstractions to bright bursts of color, Kapoor’s most celebrated series of etchings include <i>15 Etchings</i> (1996), <i>Blackness from her Womb</i> (2000), <i>12 Etchings</i> (2004), <i>Shadow</i> (2007–12), and <i>Fold</i> (2014–16).</p>',
+    "http://files.artsy.net/images/anishkapooretchings.png",
+    "<p>&copy; Anish Kapoor / Artist Rights Society (ARS), New York, NY.</p>",
+    "4de528068236f6000100070b",
+    "etching-slash-engraving",
+  ],
+  [
+    "Ansel Adams: Yosemite",
+    "ansel-adams-yosemite",
+    "Photography",
+    "",
+    "http://files.artsy.net/images/anseladamsyosemite.png",
+    "<p>Ansel Adams, <i>El Capitan, Sunrise, Yosemite National Park</i>, 1956. Courtesy of Robert Klein Gallery.</p>",
+    "4e677d4ff8597e00010072e0",
+    "",
+    "",
+    "Yosemite, El Capitan, Half Dome, Sentinel Dome, fern spring, Half Dome, nevada falls, Tuolomne Meadows",
+    "",
+    "",
+    "TRUE",
+  ],
+]

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -8,7 +8,7 @@ export const databaseConfig = () => {
   const { username, password, database, hosts, options } = parse(MONGOHQ_URL!)
   const hostName = hosts.map(a => a.host).join(",")
 
-  if (hostName === "localhost") {
+  if (hostName === "localhost" || hostName === "kaws-mongodb") {
     return {
       url: MONGOHQ_URL,
       type: "mongodb",

--- a/src/utils/__tests__/convertCSVToJSON.test.ts
+++ b/src/utils/__tests__/convertCSVToJSON.test.ts
@@ -1,6 +1,7 @@
 import * as path from "path"
 
-import { convertCSVToJSON, sanitizeSlug } from "../convertCSVToJSON"
+import { convertCSVToJSON } from "../convertCSVToJSON"
+import { sanitizeSlug } from "../sanitizeRow"
 
 describe("convertCSVToJSON", () => {
   it("converts csv to json correctly", async () => {

--- a/src/utils/convertCSVToJSON.ts
+++ b/src/utils/convertCSVToJSON.ts
@@ -1,7 +1,7 @@
 import * as csv from "csv-parser"
 import * as fs from "fs"
-import slugify from "slugify"
 import { Collection } from "../Entities/Collection"
+import { sanitizeRow } from "./sanitizeRow"
 
 export const convertCSVToJSON: (string) => Promise<Collection[]> = (
   path: string
@@ -34,27 +34,21 @@ export const convertCSVToJSON: (string) => Promise<Collection[]> = (
               show_on_editorial = false,
               is_featured_artist_content = false,
             }) =>
-              ({
+              sanitizeRow({
                 title,
-                slug: sanitizeSlug(slug),
+                slug,
                 category,
                 description,
                 headerImage,
                 credit,
-                price_guidance: price_guidance ? Number(price_guidance) : null,
-                show_on_editorial: Boolean(show_on_editorial),
-                is_featured_artist_content: Boolean(is_featured_artist_content),
-                query: (artist_ids || gene_ids || tag_id || keyword) && {
-                  artist_ids: artist_ids
-                    ? artist_ids.split(",").map(a => a.trim())
-                    : [],
-                  gene_ids: gene_ids
-                    ? gene_ids.split(",").map(a => a.trim())
-                    : [],
-                  tag_id,
-                  keyword,
-                },
-              } as Collection)
+                artist_ids,
+                gene_ids,
+                tag_id,
+                keyword,
+                price_guidance,
+                show_on_editorial,
+                is_featured_artist_content,
+              })
           )
 
           resolve(formattedCollections)
@@ -64,13 +58,4 @@ export const convertCSVToJSON: (string) => Promise<Collection[]> = (
       })
       .on("err", reject)
   })
-}
-
-export const sanitizeSlug = (slug: string) => {
-  const cleanedSlug = slugify(slug, {
-    remove: /[.'",&:\/#!$%\^\*;{}=_`’~()]/g,
-    lower: true,
-  })
-
-  return cleanedSlug
 }

--- a/src/utils/gSheetDataFetcher.ts
+++ b/src/utils/gSheetDataFetcher.ts
@@ -11,27 +11,32 @@ if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
 
 export const gSheetDataFetcher = async (
   spreadsheetID: string,
-  sheetID: string
+  sheetName: string
 ) => {
   const jwtClient = await authorize()
   const sheets = google.sheets({ version: "v4", auth: jwtClient })
-  sheets.spreadsheets.values.get(
-    {
-      spreadsheetId: spreadsheetID,
-      range: sheetID,
-    },
-    (err, res) => {
-      if (err) {
-        return console.log("The API returned an error: " + err)
+
+  return new Promise<object[]>((resolve, reject) => {
+    sheets.spreadsheets.values.get(
+      {
+        spreadsheetId: spreadsheetID,
+        range: `'${sheetName}'`,
+      },
+      (err, res) => {
+        if (err) {
+          reject(err)
+          return console.log("The API returned an error: " + err)
+        }
+        const rows = res.data.values
+        if (rows.length) {
+          resolve(rows)
+          console.log(rows)
+        } else {
+          console.log("No data found.")
+        }
       }
-      const rows = res.data.values
-      if (rows.length) {
-        console.log(rows)
-      } else {
-        console.log("No data found.")
-      }
-    }
-  )
+    )
+  })
 }
 
 const authorize = () => {
@@ -53,4 +58,4 @@ const authorize = () => {
   })
 }
 
-gSheetDataFetcher("1_lyvVK8Bz-qt3l_kcR2-2xbfr9lz_q3i1G9W77sTcvQ", "'Batch 10'")
+// gSheetDataFetcher("1_lyvVK8Bz-qt3l_kcR2-2xbfr9lz_q3i1G9W77sTcvQ", "'Batch 10'")

--- a/src/utils/gSheetDataFetcher.ts
+++ b/src/utils/gSheetDataFetcher.ts
@@ -1,18 +1,24 @@
 import { google } from "googleapis"
 
-const { GOOGLE_JWT } = process.env
-const credentials = require("../../gcloud-credentials.json")
+const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET } = process.env
 
-// https://developers.google.com/sheets/api/quickstart/nodejs?authuser=1
+if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET) {
+  console.error(
+    "[kaws] Please set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in env variables"
+  )
+  process.exit(1)
+}
 
-export const gSheetDataFetcher = async (sheetID: string) => {
-  console.log("jwt", GOOGLE_JWT!)
+export const gSheetDataFetcher = async (
+  spreadsheetID: string,
+  sheetID: string
+) => {
   const jwtClient = await authorize()
   const sheets = google.sheets({ version: "v4", auth: jwtClient })
   sheets.spreadsheets.values.get(
     {
-      spreadsheetId: "1_lyvVK8Bz-qt3l_kcR2-2xbfr9lz_q3i1G9W77sTcvQ",
-      range: "'Batch 10'",
+      spreadsheetId: spreadsheetID,
+      range: sheetID,
     },
     (err, res) => {
       if (err) {
@@ -20,7 +26,7 @@ export const gSheetDataFetcher = async (sheetID: string) => {
       }
       const rows = res.data.values
       if (rows.length) {
-        // console.log(rows)
+        console.log(rows)
       } else {
         console.log("No data found.")
       }
@@ -31,9 +37,9 @@ export const gSheetDataFetcher = async (sheetID: string) => {
 const authorize = () => {
   return new Promise((resolve, reject) => {
     const jwtClient = new google.auth.JWT(
-      credentials.client_email,
+      GOOGLE_CLIENT_ID,
       "",
-      credentials.private_key,
+      GOOGLE_CLIENT_SECRET,
       ["https://www.googleapis.com/auth/spreadsheets"]
     )
     jwtClient.authorize((err, tokens) => {
@@ -47,4 +53,4 @@ const authorize = () => {
   })
 }
 
-gSheetDataFetcher("")
+gSheetDataFetcher("1_lyvVK8Bz-qt3l_kcR2-2xbfr9lz_q3i1G9W77sTcvQ", "'Batch 10'")

--- a/src/utils/gSheetDataFetcher.ts
+++ b/src/utils/gSheetDataFetcher.ts
@@ -1,19 +1,50 @@
 import { google } from "googleapis"
 
-const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET } = process.env
+const { GOOGLE_JWT } = process.env
+const credentials = require("../../gcloud-credentials.json")
 
 // https://developers.google.com/sheets/api/quickstart/nodejs?authuser=1
 
-const SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
-
-export const gSheetDataFetcher = (sheetID: string) => {
-  const oAuth2Client = new google.auth.OAuth2(
-    GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET
+export const gSheetDataFetcher = async (sheetID: string) => {
+  console.log("jwt", GOOGLE_JWT!)
+  const jwtClient = await authorize()
+  const sheets = google.sheets({ version: "v4", auth: jwtClient })
+  sheets.spreadsheets.values.get(
+    {
+      spreadsheetId: "1_lyvVK8Bz-qt3l_kcR2-2xbfr9lz_q3i1G9W77sTcvQ",
+      range: "'Batch 10'",
+    },
+    (err, res) => {
+      if (err) {
+        return console.log("The API returned an error: " + err)
+      }
+      const rows = res.data.values
+      if (rows.length) {
+        // console.log(rows)
+      } else {
+        console.log("No data found.")
+      }
+    }
   )
+}
 
-  const authUrl = oAuth2Client.generateAuthUrl({
-    access_type: "offline",
-    scope: SCOPES,
+const authorize = () => {
+  return new Promise((resolve, reject) => {
+    const jwtClient = new google.auth.JWT(
+      credentials.client_email,
+      "",
+      credentials.private_key,
+      ["https://www.googleapis.com/auth/spreadsheets"]
+    )
+    jwtClient.authorize((err, tokens) => {
+      if (err) {
+        console.log(err)
+        reject(err)
+      } else {
+        resolve(jwtClient)
+      }
+    })
   })
 }
+
+gSheetDataFetcher("")

--- a/src/utils/gSheetDataFetcher.ts
+++ b/src/utils/gSheetDataFetcher.ts
@@ -1,0 +1,19 @@
+import { google } from "googleapis"
+
+const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET } = process.env
+
+// https://developers.google.com/sheets/api/quickstart/nodejs?authuser=1
+
+const SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+export const gSheetDataFetcher = (sheetID: string) => {
+  const oAuth2Client = new google.auth.OAuth2(
+    GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET
+  )
+
+  const authUrl = oAuth2Client.generateAuthUrl({
+    access_type: "offline",
+    scope: SCOPES,
+  })
+}

--- a/src/utils/sanitizeRow.ts
+++ b/src/utils/sanitizeRow.ts
@@ -1,0 +1,45 @@
+import slugify from "slugify"
+import { Collection } from "../Entities"
+
+export const sanitizeRow = ({
+  title,
+  slug,
+  category,
+  description,
+  headerImage,
+  credit,
+  artist_ids,
+  gene_ids,
+  tag_id,
+  keyword,
+  price_guidance,
+  show_on_editorial,
+  is_featured_artist_content,
+}) => {
+  return {
+    title,
+    slug: sanitizeSlug(slug),
+    category,
+    description,
+    headerImage,
+    credit,
+    price_guidance: price_guidance ? Number(price_guidance) : null,
+    show_on_editorial: Boolean(show_on_editorial),
+    is_featured_artist_content: Boolean(is_featured_artist_content),
+    query: (artist_ids || gene_ids || tag_id || keyword) && {
+      artist_ids: artist_ids ? artist_ids.split(",").map(a => a.trim()) : [],
+      gene_ids: gene_ids ? gene_ids.split(",").map(a => a.trim()) : [],
+      tag_id,
+      keyword,
+    },
+  } as Collection
+}
+
+export const sanitizeSlug = (slug: string) => {
+  const cleanedSlug = slugify(slug, {
+    remove: /[.'",&:\/#!$%\^\*;{}=_`’~()]/g,
+    lower: true,
+  })
+
+  return cleanedSlug
+}

--- a/src/utils/updateDatabase.ts
+++ b/src/utils/updateDatabase.ts
@@ -1,0 +1,32 @@
+import { MongoClient } from "mongodb"
+import { databaseURL } from "../config/database"
+import { Collection } from "../Entities"
+
+/**
+ * Updates the KAWS db with collection objects passed through
+ * @param collections Collection[]
+ */
+export async function updateDatabase(collections: Collection[]) {
+  const connection = await MongoClient.connect(databaseURL!)
+  const database = connection.db()
+  const collection = database.collection("collection")
+
+  try {
+    if (connection.isConnected) {
+      for (const entry of collections) {
+        await collection.update({ slug: entry.slug }, entry, { upsert: true })
+        console.log("Successfully updated: ", entry.slug, entry.title)
+      }
+
+      console.log("Successfully updated collections database")
+      connection.close()
+    }
+  } catch (error) {
+    console.error("[kaws] Error bootstrapping data:", error)
+    throw error
+  } finally {
+    /* tslint:disable:no-unused-expression */
+    connection && connection.close()
+    /* tslint:enable:no-unused-expression */
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,6 +309,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-2.0.3.tgz#b174827a732efadff81227ed4b8d1cc569baf20a"
+  integrity sha512-EPSq5wr2aFyAZ1PejJB32IX9Qd4Nwus+adnp7STYFM5/23nLPBazqZ1oor6ZqbH+4otaaGXTlC8RN5hq3C8w9Q==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
@@ -702,6 +709,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -2272,7 +2287,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2619,6 +2634,11 @@ event-lite@^0.1.1:
   resolved "https://registry.yarnpkg.com/event-lite/-/event-lite-0.1.2.tgz#838a3e0fdddef8cc90f128006c8e55a4e4e4c11b"
   integrity sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter3@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -2782,7 +2802,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@^3.0.1, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -2960,6 +2980,13 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+follow-redirects@^1.3.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
+  dependencies:
+    debug "^3.2.6"
+
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -3054,6 +3081,25 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
+
+gaxios@^1.0.4:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-1.8.2.tgz#8bc29dab0f5e296cada2c9d3ebbd0857410df15f"
+  integrity sha512-Mp6zmABg+0CxJA4b7DEWQ4ZWQzEaWxRNmHAcvCO+HU3dfoFTY925bdpZrTkLWPEtKjS9RBJKrJInzb+VtvAVYA==
+  dependencies:
+    abort-controller "^2.0.2"
+    extend "^3.0.2"
+    https-proxy-agent "^2.2.1"
+    node-fetch "^2.3.0"
+
+gcp-metadata@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-0.6.3.tgz#4550c08859c528b370459bd77a7187ea0bdbc4ab"
+  integrity sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==
+  dependencies:
+    axios "^0.18.0"
+    extend "^3.0.1"
+    retry-axios "0.3.2"
 
 generate-function@^1.0.1:
   version "1.1.0"
@@ -3230,10 +3276,42 @@ globby@8.0.1, globby@^8.0.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
+google-auth-library@^1.3.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-1.6.1.tgz#9c73d831ad720c0c3048ab89d0ffdec714d07dd2"
+  integrity sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==
+  dependencies:
+    axios "^0.18.0"
+    gcp-metadata "^0.6.3"
+    gtoken "^2.3.0"
+    jws "^3.1.5"
+    lodash.isstring "^4.0.1"
+    lru-cache "^4.1.3"
+    retry-axios "^0.3.2"
+
 google-libphonenumber@^3.1.6:
   version "3.1.14"
   resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.1.14.tgz#be67b52c33590deb568e5c3faa6f811aa5d7a8eb"
   integrity sha512-87znRJE3r3hX3wXIIftIXNBoFw7AqbDpfih3JIVD5FA47ZhkWOCVTOBReGgqZgq+H5KU6t+8/E0MrcbWTyjYwQ==
+
+google-p12-pem@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-1.0.4.tgz#b77fb833a2eb9f7f3c689e2e54f095276f777605"
+  integrity sha512-SwLAUJqUfTB2iS+wFfSS/G9p7bt4eWcc2LyfvmUXe7cWp6p3mpxDo6LLI29MXdU6wvPcQ/up298X7GMC5ylAlA==
+  dependencies:
+    node-forge "^0.8.0"
+    pify "^4.0.0"
+
+googleapis@27:
+  version "27.0.0"
+  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-27.0.0.tgz#c210633b43e7047b65d33da40c489b6d8f9c02b8"
+  integrity sha512-Cz0BRsZmewc21N50x5nAUW5cqaGhJ9ETQKZMGqGL4BxmCV7ETELazSqmNi4oCDeRwM4Iub/fIJWAWZk2i6XLCg==
+  dependencies:
+    google-auth-library "^1.3.1"
+    pify "^3.0.0"
+    qs "^6.5.1"
+    string-template "1.0.0"
+    uuid "^3.2.1"
 
 got@8.3.2:
   version "8.3.2"
@@ -3423,6 +3501,17 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+gtoken@^2.3.0:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-2.3.3.tgz#8a7fe155c5ce0c4b71c886cfb282a9060d94a641"
+  integrity sha512-EaB49bu/TCoNeQjhCYKI/CurooBKkGxIqFHsWABW0b25fobBYVTMe84A8EBVVZhl8emiUdNypil9huMOTmyAnw==
+  dependencies:
+    gaxios "^1.0.4"
+    google-p12-pem "^1.0.0"
+    jws "^3.1.5"
+    mime "^2.2.0"
+    pify "^4.0.0"
 
 handlebars@^4.0.2:
   version "4.0.12"
@@ -5090,7 +5179,7 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@^4.0.1:
+lru-cache@^4.0.1, lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -5295,6 +5384,11 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
+
+mime@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
+  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -5521,6 +5615,11 @@ node-fetch@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.3.0.tgz#1a1d940bbfb916a1d3e0219f037e89e71f8c5fa5"
   integrity sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==
+
+node-forge@^0.8.0:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.2.tgz#b4bcc59fb12ce77a8825fc6a783dfe3182499c5a"
+  integrity sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -6102,6 +6201,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pify@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -6266,6 +6370,11 @@ qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+qs@^6.5.1:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
 query-string@^5.0.1:
   version "5.1.1"
@@ -6736,6 +6845,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry-axios@0.3.2, retry-axios@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-0.3.2.tgz#5757c80f585b4cc4c4986aa2ffd47a60c6d35e13"
+  integrity sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ==
 
 retry@0.10.1:
   version "0.10.1"
@@ -7208,6 +7322,11 @@ string-length@^2.0.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
+
+string-template@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string-template/-/string-template-1.0.0.tgz#9e9f2233dc00f218718ec379a28a5673ecca8b96"
+  integrity sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -7826,7 +7945,7 @@ uuid@3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
   integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
 
-uuid@3.3.2, uuid@^3.1.0, uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1345,7 +1345,7 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
-body-parser@^1.18.2:
+body-parser@^1.18.2, body-parser@^1.18.3:
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
   integrity sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/GROW-1144

We make use of the Google Sheets API to get update KAWS. The goal is enable admins to update and ingest data without engineering intervention. This is only one part of enabling this, the google sheet script needs this endpoint to post the current googlesheet id the user wants to update.

In terms of security, this script uses a JWT which only has permissions to read a particular google sheet from artsy's google account.

1. Adds express route to handle import request from Google Sheet script
2. Extract data sanitization helper method to its own module for reuse
3. Fixes `hokusai dev start` and our docker compose config