### PR TITLE
Use inherited circle context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,6 @@ workflows:
               ignore:
                 - staging
       - push:
-          context: hokusai
           filters:
             branches:
               only:
@@ -81,14 +80,12 @@ workflows:
           requires:
             - test
       - deploy-staging:
-          context: hokusai
           filters:
             branches:
               only: master
           requires:
             - push
       - deploy-production:
-          context: hokusai
           filters:
             branches:
               only: release


### PR DESCRIPTION
I believe that the issues with keys failing on deploy was due to an incorrect key in the context. This removes changes from https://github.com/artsy/kaws/pull/91. The hokusai context should be inherited from the `test` job, which is required for all steps.