### PR TITLE
Update priceGuidance script to still work with less data

### DIFF
--- a/src/utils/__tests__/getPriceGuidance.test.ts
+++ b/src/utils/__tests__/getPriceGuidance.test.ts
@@ -75,7 +75,7 @@ describe("#getPriceGuidance", () => {
     expect(avgPrice).toEqual(null)
   })
 
-  it("returns null if priceCents for an artwork is null", async () => {
+  it("returns an avgPrice even when priceCents for one or more artworks is null", async () => {
     const results = {
       marketingCollection: {
         artworks: {
@@ -113,10 +113,10 @@ describe("#getPriceGuidance", () => {
     const avgPrice = await getPriceGuidance("kaws-toys")
 
     expect(mockMetaphysics.mock.calls[0][0]).toContain("kaws-toys")
-    expect(avgPrice).toEqual(null)
+    expect(avgPrice).toEqual(300)
   })
 
-  it("returns null if there not at least 5 values for priceCents", async () => {
+  it("returns an average price even when there are less than 5 values for priceCents", async () => {
     const results = {
       marketingCollection: {
         artworks: {
@@ -148,7 +148,7 @@ describe("#getPriceGuidance", () => {
     const avgPrice = await getPriceGuidance("kaws-snoopy")
 
     expect(mockMetaphysics.mock.calls[0][0]).toContain("kaws-snoopy")
-    expect(avgPrice).toEqual(null)
+    expect(avgPrice).toEqual(300)
   })
 })
 


### PR DESCRIPTION
We realized we were being too strict with the price guidance. Namely
- still compute a value if one of the 5 price values is `null`
- still computer a value if we have less than 5 seeds