### PR TITLE
[Related Collections Footer] filter collections by category

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -81,6 +81,7 @@ scalar DateTime
 
 type Query {
   collections(
+    category: String
     randomizationSeed: String
     size: Int
     isFeaturedArtistContent: Boolean

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -15,7 +15,8 @@ export class CollectionsResolver {
     @Arg("isFeaturedArtistContent", { nullable: true })
     isFeaturedArtistContent: boolean,
     @Arg("size", () => Int, { nullable: true }) size: number,
-    @Arg("randomizationSeed", { nullable: true }) randomizationSeed: string
+    @Arg("randomizationSeed", { nullable: true }) randomizationSeed: string,
+    @Arg("category", { nullable: true }) category: string
   ): Promise<Collection[]> {
     const hasArguments =
       [].filter.call(arguments, arg => arg !== undefined).length > 0
@@ -32,6 +33,10 @@ export class CollectionsResolver {
     }
     if (!randomizationSeed && size) {
       query.take = size
+    }
+
+    if (category !== undefined) {
+      query.where.category = { $in: [category] }
     }
 
     if (randomizationSeed) {

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -234,6 +234,24 @@ describe("Collections", () => {
       ])
     })
   })
+
+  it("can filter collections by category", () => {
+    const query = `
+      {
+        collections(category: "Pop Art") {
+          id
+        }
+      }
+    `
+
+    return runQuery(query, {}, createMockSchema).then(data => {
+      expect(find).toBeCalledWith({
+        where: {
+          category: { $in: ["Pop Art"] },
+        },
+      })
+    })
+  })
 })
 
 describe("Categories", () => {

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -83,7 +83,7 @@ type CollectionQuery {
 scalar DateTime
 
 type Query {
-  collections(randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean, artistID: String): [Collection!]!
+  collections(category: String, randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean, artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
 }


### PR DESCRIPTION
Addresses: [GROW-1272](https://artsyproduct.atlassian.net/browse/GROW-1272)

While working on [Related Collections Footer Rail](https://artsyproduct.atlassian.net/browse/GROW-1228), I noticed that we don't yet have the ability to pass `category` as an argument to `marketingCollections` and filter by a specific category. This PR adds that capability. 