### PR TITLE
adds relatedCollections field resolver

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -36,6 +36,7 @@ type Collection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+  relatedCollections: [Collection!]!
 }
 
 type CollectionCategory {

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -97,7 +97,10 @@ export class CollectionsResolver {
     }
 
     const relatedCategoryResults = await this.repository.find({
-      where: { category: { $in: [collection.category] } },
+      where: {
+        category: { $in: [collection.category] },
+        show_on_editorial: true,
+      },
     })
     const relatedCategoryCollections = reject(relatedCategoryResults, {
       id: collection.id,

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -316,4 +316,63 @@ describe("Collection", () => {
       })
     })
   })
+  it("returns related artist collections", () => {
+    const query = `
+      {
+        collection(slug: "kaws-companions") {
+          id
+          title
+          slug
+          category
+          query {
+            id
+            artist_ids
+          }
+          relatedCollections {
+            id
+            slug
+            title
+          }
+        }
+      }
+    `
+
+    return runQuery(query, {}, createMockSchema).then(data => {
+      expect(find).toBeCalledWith({
+        where: {
+          "query.artist_ids": { $in: ["123"] },
+        },
+      })
+    })
+  })
+
+  it("returns related category collections", () => {
+    const query = `
+      {
+        collection(slug: "jasper-johns-flags") {
+          id
+          title
+          slug
+          category
+          query {
+            id
+            artist_ids
+          }
+          relatedCollections {
+            id
+            slug
+            title
+          }
+        }
+      }
+    `
+
+    return runQuery(query, {}, createMockSchema).then(data => {
+      expect(find).toBeCalledWith({
+        where: {
+          category: { $in: ["Pop Art"] },
+        },
+      })
+    })
+  })
 })

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -371,6 +371,7 @@ describe("Collection", () => {
       expect(find).toBeCalledWith({
         where: {
           category: { $in: ["Pop Art"] },
+          show_on_editorial: true,
         },
       })
     })

--- a/src/Resolvers/__tests__/fixtures/data.ts
+++ b/src/Resolvers/__tests__/fixtures/data.ts
@@ -12,6 +12,7 @@ export const mockCollectionRepository = plainToClass(Collection, [
     headerImage: "",
     query: {
       id: null,
+      artist_ids: ["123"],
       tag_id: "companion",
     },
     createdAt: Date.now(),

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -39,6 +39,7 @@ type Collection {
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+  relatedCollections: [Collection!]!
 }
 
 type CollectionCategory {


### PR DESCRIPTION
Addresses: [GROW-1228](https://artsyproduct.atlassian.net/browse/GROW-1228)

This adds `relatedCollections` to be used in the RelatedCollectionsRail as a top level property via a [`FieldResolver`](https://github.com/19majkel94/type-graphql/blob/master/docs/resolvers.md#field-resolvers).