### PR TITLE
update ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ jobs:
       - run:
           name: Update staging branch
           command:
-            git push git@github.com:artsy/kaws.git $CIRCLE_SHA1:staging --force
+            git push git@github.com:artsy/kaws.git
+            $CIRCLE_SHA1:refs/heads/staging --force
       - run:
           name: Deploy staging assets
           command: hokusai staging deploy $CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,7 @@ jobs:
       - run:
           name: Configure hokusai
           command:
-            hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel
-            --s3-key k8s/config --platform linux
+            hokusai configure --kubectl-version 1.10.7 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
       - run:
           name: Validate Kubernetes Yaml
           command: |
@@ -38,8 +37,7 @@ jobs:
       - run:
           name: Update staging branch
           command:
-            git push git@github.com:artsy/kaws.git
-            $CIRCLE_SHA1:refs/heads/staging --force
+            git push git@github.com:artsy/kaws.git $CIRCLE_SHA1:refs/heads/staging --force
       - run:
           name: Deploy staging assets
           command: hokusai staging deploy $CIRCLE_SHA1


### PR DESCRIPTION
This updates the CI config "Update staging branch" command to explicitly specify a branch rather than a tag and resolves `error: unable to push to unqualified destination: staging` in https://circleci.com/gh/artsy/kaws/436