### PR TITLE
added support for integration tests that actually hit the database

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,21 @@
+NODE_ENV=test
+PORT=4000
+APP_NAME=kaws-test
+DD_APM_ENABLED=false
+
+# Needed to push content to Sailthru - different versions exist for staging and
+# production instances!
+SAILTHRU_KEY=
+SAILTHRU_SECRET=
+
+# For connecting to Metaphysics, Artsy's GraphQL service, to retreive artwork
+# and artist data associated with a collection
+METAPHYSICS_URL=
+
+# Database auth
+MONGOHQ_URL=mongodb://localhost:27017/kaws-test
+
+# Google Sheets credentials
+GOOGLE_CLIENT_ID=REPLACE
+GOOGLE_CLIENT_SECRET=REPLACE
+

--- a/.env.test
+++ b/.env.test
@@ -3,19 +3,7 @@ PORT=4000
 APP_NAME=kaws-test
 DD_APM_ENABLED=false
 
-# Needed to push content to Sailthru - different versions exist for staging and
-# production instances!
-SAILTHRU_KEY=
-SAILTHRU_SECRET=
-
-# For connecting to Metaphysics, Artsy's GraphQL service, to retreive artwork
-# and artist data associated with a collection
-METAPHYSICS_URL=
-
 # Database auth
 MONGOHQ_URL=mongodb://localhost:27017/kaws-test
 
-# Google Sheets credentials
-GOOGLE_CLIENT_ID=REPLACE
-GOOGLE_CLIENT_SECRET=REPLACE
 

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - ELASTICSEARCH_URL=http://kaws-elasticsearch:9200
       - MONGOHQ_URL=mongodb://kaws-mongodb:27017/kaws-test
+    env_file: ../.env.test
     depends_on:
       - kaws-mongodb
       - kaws-elasticsearch

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -1,8 +1,27 @@
----
-version: '2'
+version: "2"
 services:
   kaws:
     command: ["yarn", "test"]
     extends:
       file: build.yml
       service: kaws
+    environment:
+      - ELASTICSEARCH_URL=http://kaws-elasticsearch:9200
+      - MONGOHQ_URL=mongodb://kaws-mongodb:27017/kaws-test
+    depends_on:
+      - kaws-mongodb
+      - kaws-elasticsearch
+  kaws-elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+  kaws-mongodb:
+    image: mongo:4.0
+    ports:
+      - "27017:27017"
+    command: ["--storageEngine=mmapv1", "--quiet", "--nojournal"]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "jest": {
     "preset": "ts-jest",
+    "setupFiles": ["<rootDir>/src/test/config.ts"],
     "testMatch": [
       "**/__tests__/**/*test.ts"
     ],

--- a/src/__tests__/insert.test.ts
+++ b/src/__tests__/insert.test.ts
@@ -1,0 +1,58 @@
+import { Connection, createConnection } from "typeorm"
+import { databaseConfig } from "../config/database"
+import { Collection } from "../Entities"
+
+const init = async () => {
+  try {
+    const connectionArgs = databaseConfig()
+    const connection: Connection = await createConnection(connectionArgs)
+    return connection
+  } catch (error) {
+    console.error("[kaws] Error to connecting to MongoDB:", error)
+  }
+}
+
+describe.only("CRUD operations work", () => {
+  let connection
+  beforeAll(async () => {
+    connection = await init()
+  })
+  beforeEach(async () => {
+    try {
+      connection.getRepository(Collection).clear()
+    } catch (e) {
+      console.warn(e.message)
+    }
+  })
+  afterAll(async () => {
+    connection.close()
+  })
+  it("can retrieve a saved entity", async () => {
+    const collectionRepository = connection.getRepository(Collection)
+
+    const testCollection = {
+      title: "KAWS: Toys",
+      slug: "kaws-toys",
+      category: "Collectible Sculptures",
+      description:
+        '<p>Brian Donnelly, the ex-Disney illustrator better known as KAWS, created his first vinyl toy in 1999: an eight-inch “<a href="https://www.artsy.net/collection/kaws-companions">Companion</a>” whose round belly, noodly limbs, and white gloves immediately reminded viewers of the cartoons made famous by his former workplace. The limited edition toy, produced in collaboration with the Japanese brand Bounty Hunter, reflected KAWS’s desire to make his work more accessible to the public. In the years since, KAWS has rendered most of his signature characters in three dimensions, including Chum, Bendy, and Blitz, as well as his renditions of iconic cartoons like Tweety, <a href="https://www.artsy.net/collection/kaws-snoopy">Snoopy</a>, and <a href="https://www.artsy.net/collection//kaws-pinocchio">Pinocchio</a>. When first released, these sculptures often sell out in just seconds. When the Museum of Modern Art promoted KAWS’s toys in its design store, collector demand was so high that the museum’s website crashed multiple times.</p>',
+      headerImage:
+        "https://artsy-vanity-files-production.s3.amazonaws.com/images/kaws2.png",
+      credit: "<p>&copy; KAWS, Medicom Toy 2007.</p>",
+      query: {
+        artist_ids: ["4e934002e340fa0001005336"],
+        gene_ids: ["sculpture", "related-to-toys"],
+        tag_id: "",
+        keyword:
+          "Companion, BFF, Passing Through, Astroboy, Astro Boy, Small Lie, Together, Accomplice, Twins, Stormtrooper, Boba Fett, Darth Vader, Undercover Bear, Tweety, Pinocchio, Resting Place, Along the Way, Final Days, Zooth, Tweety, Joe Kaws, Snoopy, Seeing Watching, Pinocchio, Jiminy Cricket, Partners, Milo, Kubrick, Zooth, Bounty Hunter, Bearbrick, Chum, JPP, Final Days, Chompers, Cat Teeth Bank, Bend, Blitz, Bendy, Accomplice",
+      },
+    } as Collection
+
+    const savedCollection = await collectionRepository.save(testCollection)
+    const readCollection = await collectionRepository.findOne({
+      _id: savedCollection._id,
+    })
+
+    expect(readCollection.slug).toBe(testCollection.slug)
+  })
+})

--- a/src/__tests__/insert.test.ts
+++ b/src/__tests__/insert.test.ts
@@ -19,13 +19,14 @@ describe.only("CRUD operations work", () => {
   })
   beforeEach(async () => {
     try {
-      connection.getRepository(Collection).clear()
+      await connection.getRepository(Collection).clear()
     } catch (e) {
-      console.warn(e.message)
+      // This will fail the first time it runs because there's nothing to clear.
+      // it's no big.
     }
   })
   afterAll(async () => {
-    connection.close()
+    await connection.close()
   })
   it("can retrieve a saved entity", async () => {
     const collectionRepository = connection.getRepository(Collection)

--- a/src/test/config.ts
+++ b/src/test/config.ts
@@ -1,0 +1,2 @@
+const dotenv = require("dotenv")
+dotenv.config({ path: "./.env.test" })


### PR DESCRIPTION
This adds integration tests to Kaws, with one example. Most of this PR is configuration tweaking to make things fit - the Hokusai testing yaml has not yet been tested. @l2succes and @anandaroop and I mobbed on this.

Diff Analysis (experimental): 
```
{
  "total_files_changed": 5,
  "test_files_changed": 4,
  "by_type": {
    "yml": 1,
    "ts": 2,
    "test": 1,
    "json": 1
  }
}
```