### PR TITLE
don't push redundant image on production deploy #PLATFORM-1596

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,5 @@ workflows:
             - push-staging-image
 
       # release
-      - hokusai/push:
-          name: push-production-image
-          <<: *only_release
       - hokusai/deploy-production:
           <<: *only_release
-          requires:
-            - push-production-image


### PR DESCRIPTION
`hokusai/deploy-production` calls `hokusai pipeline promote` to deploy the image currently deployed on staging, so a build on the merge commit on release is unnecessary