### PR TITLE
Linked collections

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -51,10 +51,9 @@ type CollectionCategory {
 }
 
 type CollectionGroup {
-  id: ID!
   groupType: GroupTypes!
   name: String!
-  members: [String!]!
+  members: [Collection!]!
 }
 
 type CollectionQuery {
@@ -98,6 +97,13 @@ enum GroupTypes {
   ArtistSeries
   FeaturedCollections
   OtherCollections
+}
+
+type Image {
+  id: ID!
+  small: String!
+  medium: String!
+  large: String!
 }
 
 type Query {

--- a/src/Entities/Collection.ts
+++ b/src/Entities/Collection.ts
@@ -98,6 +98,6 @@ export class Collection {
   @Field(type => [CollectionGroup], {
     description: "CollectionGroups of this collection",
   })
-  @Column({ default: [] })
+  @Column(type => CollectionGroup)
   linkedCollections: CollectionGroup[]
 }

--- a/src/Entities/CollectionGroup.ts
+++ b/src/Entities/CollectionGroup.ts
@@ -1,5 +1,6 @@
-import { Field, ID, ObjectType, registerEnumType } from "type-graphql"
+import { Field, ObjectType, registerEnumType } from "type-graphql"
 import { Column, Entity, ObjectID, ObjectIdColumn } from "typeorm"
+import { Collection } from "./Collection"
 
 export enum GroupType {
   ArtistSeries,
@@ -15,7 +16,6 @@ registerEnumType(GroupType, {
 @ObjectType()
 @Entity()
 export class CollectionGroup {
-  @Field(type => ID)
   @ObjectIdColumn()
   id: ObjectID
 
@@ -27,7 +27,7 @@ export class CollectionGroup {
   @Column()
   name: string
 
-  @Field(type => [String!]!, { nullable: false })
+  @Field(type => [Collection], { nullable: false })
   @Column()
-  members: string[] = []
+  members: Collection[] = []
 }

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -1,6 +1,7 @@
 import { isEmpty, reject } from "lodash"
 import { Arg, FieldResolver, Int, Query, Resolver, Root } from "type-graphql"
 import { getMongoRepository } from "typeorm"
+import { CollectionGroup } from "../Entities"
 import { Collection } from "../Entities/Collection"
 import { CollectionCategory } from "../Entities/CollectionCategory"
 
@@ -122,12 +123,21 @@ export class CollectionsResolver {
     return relatedCategoryCollections
   }
 
-  // @Mutation(type => Collection)
-  // async createCollection(@Arg("collectionInput") collectionInput: AddCollectionInput): Promise<Collection> {
-  //   const collection = this.repository.create(collectionInput)
+  @FieldResolver(type => [CollectionGroup])
+  async linkedCollections(
+    @Root() collection: Collection
+  ): Promise<CollectionGroup[]> {
+    const groups = await collection.linkedCollections.map(
+      async linkedCollection => {
+        return {
+          ...linkedCollection,
+          members: await this.repository.find({
+            where: { slug: { $in: linkedCollection.members } },
+          }),
+        } as CollectionGroup
+      }
+    )
 
-  //   // TODO: validate input
-
-  //   return await this.repository.save(collection)
-  // }
+    return await Promise.all(groups)
+  }
 }

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -54,10 +54,9 @@ type CollectionCategory {
 }
 
 type CollectionGroup {
-  id: ID!
   groupType: GroupTypes!
   name: String!
-  members: [String!]!
+  members: [Collection!]!
 }
 
 type CollectionQuery {
@@ -101,6 +100,13 @@ enum GroupTypes {
   ArtistSeries
   FeaturedCollections
   OtherCollections
+}
+
+type Image {
+  id: ID!
+  small: String!
+  medium: String!
+  large: String!
 }
 
 type Query {


### PR DESCRIPTION
The initial schema resolves the `members` array to string ids not Collection object, this is fixed in this PR.

Enables the following query:

```graphql
{
  collection(slug: "street-art-now") {
    id
    slug
    title
    description
    headerImage
    linkedCollections {
      groupType
      members {
         slug
         title
         headerImage
      }
    }
  }
}
```