### PR TITLE
Protects /upload by allowing whitelist only ids

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,4 +6,5 @@ DD_APM_ENABLED=false
 # Database auth
 MONGOHQ_URL=mongodb://localhost:27017/kaws-test
 
+SPREADSHEET_IDS_WHITELIST=test_id123
 

--- a/src/Routes/GSheetImport.ts
+++ b/src/Routes/GSheetImport.ts
@@ -4,6 +4,8 @@ import { gSheetDataFetcher } from "../utils/gSheetDataFetcher"
 import { sanitizeRow } from "../utils/sanitizeRow"
 import { updateDatabase } from "../utils/updateDatabase"
 
+const { SPREADSHEET_IDS_WHITELIST } = process.env
+
 const app = express()
 
 app.use(bodyParser.json())
@@ -14,11 +16,16 @@ export const upload = async (
   next: express.NextFunction
 ) => {
   const { spreadSheetID, sheetName } = req.body
+  const authorizedIDs = (SPREADSHEET_IDS_WHITELIST || "").split(",")
 
   if (!spreadSheetID || !sheetName) {
     return res
       .status(500)
       .send("A valid spreadSheetID and sheetName is required")
+  }
+
+  if (!authorizedIDs.includes(spreadSheetID)) {
+    return res.status(500).send("A valid spreadSheetID is required")
   }
 
   let data: object[]

--- a/src/Routes/__tests__/GSheetImport.test.ts
+++ b/src/Routes/__tests__/GSheetImport.test.ts
@@ -39,7 +39,7 @@ describe("GSheetImport", () => {
 
     it("Calls updateDatabase with downloaded rows data", async () => {
       req.body = {
-        spreadSheetID: "123",
+        spreadSheetID: "test_id123",
         sheetName: "'All'",
       }
 
@@ -123,6 +123,18 @@ describe("GSheetImport", () => {
       ])
 
       expect(res.send).toBeCalledWith(200)
+    })
+
+    it("responds with 500 if spreadsheetID is not in whitelist", async () => {
+      req.body = {
+        spreadSheetID: "not_in_whitelist_123",
+        sheetName: "'All'",
+      }
+
+      await upload(req, res, next)
+
+      expect(res.status).toBeCalledWith(500)
+      expect(res.send).toBeCalledWith("A valid spreadSheetID is required")
     })
   })
 })

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -54,10 +54,9 @@ type CollectionCategory {
 }
 
 type CollectionGroup {
-  id: ID!
   groupType: GroupTypes!
   name: String!
-  members: [String!]!
+  members: [Collection!]!
 }
 
 type CollectionQuery {
@@ -101,6 +100,13 @@ enum GroupTypes {
   ArtistSeries
   FeaturedCollections
   OtherCollections
+}
+
+type Image {
+  id: ID!
+  small: String!
+  medium: String!
+  large: String!
 }
 
 type Query {


### PR DESCRIPTION
It has been brought to our attention the `/upload` endpoint was vulnerable to attacks by allowing any arbitrary spreadsheet IDs through since no validation was being performed (More details [here](https://trello.com/c/1amQXMw0/185-upload-of-attacker-controlled-data-in-kaws-stored-xss-potential-dos)).

We fix this issue by checking the spreadsheet ID against a secure and Artsy controlled whitelist.