### PR TITLE
added cronjobs to prod and staging for updating sailthru

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -137,6 +137,7 @@ spec:
                 - configMapRef:
                     name: kaws-environment
           restartPolicy: Never
+          backoffLimit: 2
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -113,3 +113,37 @@ spec:
     component: web
   sessionAffinity: None
   type: LoadBalancer
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: kaws-update-sailthu
+spec:
+  schedule: 13 13 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: kaws-update-sailthru
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/kaws:production
+              args:
+                - "yarn"
+                - "run"
+                - "update-sailthru"
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -137,6 +137,7 @@ spec:
                 - configMapRef:
                     name: kaws-environment
           restartPolicy: Never
+          backoffLimit: 2
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -113,3 +113,37 @@ spec:
     component: web
   sessionAffinity: None
   type: LoadBalancer
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: kaws-update-sailthu
+spec:
+  schedule: 13 13 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: kaws-update-sailthru
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/kaws:staging
+              args:
+                - "yarn"
+                - "run"
+                - "update-sailthru"
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background


### PR DESCRIPTION
This PR is meant to satisfy [GROW-1381](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=4&projectKey=GROW&modal=detail&selectedIssue=GROW-1381&quickFilter=7), which is a request to re-enable automated sailthru updates.

I followed the link the JIRA ticket to the diffusion example, and brought it over while swapping out everything that seemed like it needed to change. I've updated both prod and staging Hokusai config files, and I ran the task locally using staging data - it succeeded. 

I'd appreciate some :eyes: on my .yaml changes, though, this isn't a space I've spent much time exploring. Tagging @izakp on this since he's the Hokusai king!

Diff Analysis: 
```
{
  "total_files_changed": 2,
  "test_files_changed": 0,
  "by_type": {
    "yml": 2
  }
}
```