### PR TITLE
Add CronJobs for updating elastic search

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -136,7 +136,7 @@ spec:
               envFrom:
                 - configMapRef:
                     name: kaws-environment
-          restartPolicy: Neve
+          restartPolicy: Never
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -148,3 +148,38 @@ spec:
                         values:
                           - background
       backoffLimit: 2
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: kaws-update-elastic-search
+spec:
+  schedule: 7 15 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: kaws-update-elastic-search
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/kaws:production
+              args:
+                - "yarn"
+                - "run"
+                - "index-for-search"
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background
+      backoffLimit: 2

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -148,3 +148,38 @@ spec:
                         values:
                           - background
       backoffLimit: 2
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: kaws-update-elastic-search
+spec:
+  schedule: 7 15 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: kaws-update-elastic-search
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/kaws:staging
+              args:
+                - "yarn"
+                - "run"
+                - "index-for-search"
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background
+      backoffLimit: 2


### PR DESCRIPTION
NOTE: I based this PR on [this one](https://github.com/artsy/kaws/pull/127), both add new cronjobs and it seemed conflicty to do two from scratch. We should merge that one first, then rebase this one if necessary and merge it.

I ran this locally against staging data and it seemed to work without a hitch.

Like before, since this is Hokusai-related I'm tagging @izakp, and @anandaroop I've got you as the assignee but happy to change that?

Diff Analysis: 
```
{
  "total_files_changed": 2,
  "test_files_changed": 0,
  "by_type": {
    "yml": 2
  }
}
```