### PR TITLE
Fixes backoffLimit position in hokusai configs

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -136,8 +136,7 @@ spec:
               envFrom:
                 - configMapRef:
                     name: kaws-environment
-          restartPolicy: Never
-          backoffLimit: 2
+          restartPolicy: Neve
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -148,3 +147,4 @@ spec:
                         operator: In
                         values:
                           - background
+      backoffLimit: 2

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -137,7 +137,6 @@ spec:
                 - configMapRef:
                     name: kaws-environment
           restartPolicy: Never
-          backoffLimit: 2
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -148,3 +147,4 @@ spec:
                         operator: In
                         values:
                           - background
+      backoffLimit: 2


### PR DESCRIPTION
I noticed the following error on this [CI staging build](https://circleci.com/gh/artsy/kaws/564?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

```
error: error validating "/root/project/hokusai/staging.yml": error validating data: ValidationError(CronJob.spec.jobTemplate.spec.template.spec): unknown field "backoffLimit" in io.k8s.api.core.v1.PodSpec; if you choose to ignore these errors, turn validation off with --validate=false
ERROR: Command 'kubectl --context staging apply -f /root/project/hokusai/staging.yml --dry-run' returned non-zero exit status 1
```

Figured out the issue by consulting the kubernetes docs for cron job configs
https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#running-an-example-job

For future reference, you can validate a hokusai (kubernetes) config by running the following command.
`kubectl apply --validate=true --dry-run=true --filename=hokusai/production.yml`

If you notice an error there, it means the config is invalid