### PR TITLE
fixes problems in spreadsheet ingestion

### DIFF
--- a/scripts/bootstrapOrUpdate.ts
+++ b/scripts/bootstrapOrUpdate.ts
@@ -12,8 +12,8 @@ const csvFile = process.argv[2]
  * @usage yarn update-database ./fixtures/collections.csv
  */
 export async function bootstrapOrUpdate(path: string) {
-  const data = await convertCSVToJSON(path)
   try {
+    const data = await convertCSVToJSON(path)
     await updateDatabase(data)
     process.exit(0)
   } catch (e) {

--- a/src/Routes/GSheetImport.ts
+++ b/src/Routes/GSheetImport.ts
@@ -84,10 +84,16 @@ export const upload = async (
       other_collections,
     }
   })
-  const rows = validateAndSanitizeInput(input)
-  updateDatabase(rows)
 
-  res.send(200)
+  try {
+    const rows = validateAndSanitizeInput(input)
+    await updateDatabase(rows)
+    res.send(200)
+  } catch (e) {
+    console.log("There was an error uploading collection data.")
+    console.log(e.message)
+    res.status(500).send(e.message)
+  }
 }
 
 app.post("/upload", upload)

--- a/src/utils/convertCSVToJSON.ts
+++ b/src/utils/convertCSVToJSON.ts
@@ -18,8 +18,12 @@ export const convertCSVToJSON: (string) => Promise<Collection[]> = (
       .on("data", data => results.push(data))
       .on("end", async () => {
         if (results.length > 0) {
-          const formattedCollections = validateAndSanitizeInput(results)
-          resolve(formattedCollections)
+          try {
+            const formattedCollections = validateAndSanitizeInput(results)
+            resolve(formattedCollections)
+          } catch (e) {
+            reject(e)
+          }
         } else {
           resolve([])
         }

--- a/src/utils/gSheetDataFetcher.ts
+++ b/src/utils/gSheetDataFetcher.ts
@@ -29,10 +29,11 @@ export const gSheetDataFetcher = async (
         }
         const rows = res.data.values
         if (rows.length) {
+          console.log(`Processing ${rows.length} rows.`)
           resolve(rows)
-          console.log(rows)
         } else {
           console.log("No data found.")
+          reject([])
         }
       }
     )

--- a/src/utils/processInput.ts
+++ b/src/utils/processInput.ts
@@ -1,31 +1,36 @@
 import slugify from "slugify"
 import { Collection, CollectionGroup, GroupType } from "../Entities"
 
-const validate = (input) => {
+const validate = input => {
   const by_slug = input.reduce((acc, val) => ({ ...acc, [val.slug]: true }), {})
-  const bad_slugs = new Set();
+  const bad_slugs = new Set()
 
-  const process_link = slug_string => slug_string
-    .split(",")
-    .forEach(slug => {
+  const process_link = slug_string =>
+    slug_string.split(",").forEach(slug => {
       if (slug && !by_slug[slug]) {
         bad_slugs.add(slug)
       }
     })
 
-  input.forEach(({ artist_series, featured_collections, other_collections }) => {
-    artist_series && process_link(artist_series)
-    featured_collections && process_link(featured_collections)
-    other_collections && process_link(other_collections)
-  })
+  input.forEach(
+    ({ artist_series, featured_collections, other_collections }) => {
+      artist_series && process_link(artist_series)
+      featured_collections && process_link(featured_collections)
+      other_collections && process_link(other_collections)
+    }
+  )
 
   return bad_slugs
 }
 
 export const validateAndSanitizeInput = rows => {
   const bad_slugs = validate(rows)
+  console.log("Validation errors found:", bad_slugs.size)
   if (bad_slugs.size > 0) {
-    throw new Error("Unable to resolve one or more linked slugs: " + Array.from(bad_slugs).join(" | "))
+    throw new Error(
+      "Unable to resolve one or more linked slugs: " +
+        Array.from(bad_slugs).join(" | ")
+    )
   }
   return rows.map(sanitizeRow)
 }


### PR DESCRIPTION
This PR cleans up a number of small issues which have, in combination, caused some problems with our collection ingestion flow. We noticed a few important problems:

1. The validation logic worked, but the way users were notified of invalid data was incorrect - we were failing silently and timing out. This PR addresses that.
2. As we debugged this we identified at least one place with a missing `await` statement, and cleaned up a number of places where error output wasn't flowing as gracefully as we wanted.

Diff Analysis: 
```
{
  "total_files_changed": 5,
  "test_files_changed": 0,
  "by_type": {
    "ts": 5
  }
}
```