### PR TITLE
reverts data validation logic

### DIFF
--- a/src/Routes/GSheetImport.ts
+++ b/src/Routes/GSheetImport.ts
@@ -1,7 +1,7 @@
 import * as bodyParser from "body-parser"
 import * as express from "express"
 import { gSheetDataFetcher } from "../utils/gSheetDataFetcher"
-import { validateAndSanitizeInput } from "../utils/processInput"
+import { sanitizeRow } from "../utils/processInput"
 import { updateDatabase } from "../utils/updateDatabase"
 
 const { SPREADSHEET_IDS_ALLOWLIST } = process.env
@@ -37,7 +37,7 @@ export const upload = async (
     return res.status(500).send(e.message)
   }
 
-  const input = data.slice(1).map((row: string[]) => {
+  const rows = data.slice(1).map((row: string[]) => {
     const [
       title,
       slug,
@@ -61,7 +61,7 @@ export const upload = async (
       other_collections,
     ] = row
 
-    return {
+    return sanitizeRow({
       title,
       slug,
       category,
@@ -82,11 +82,10 @@ export const upload = async (
       featured_collections,
       other_collections_label,
       other_collections,
-    }
+    })
   })
 
   try {
-    const rows = validateAndSanitizeInput(input)
     await updateDatabase(rows)
     res.send(200)
   } catch (e) {

--- a/src/utils/convertCSVToJSON.ts
+++ b/src/utils/convertCSVToJSON.ts
@@ -1,7 +1,7 @@
 import * as csv from "csv-parser"
 import * as fs from "fs"
 import { Collection } from "../Entities/Collection"
-import { validateAndSanitizeInput } from "./processInput"
+import { sanitizeRow } from "./processInput"
 
 export const convertCSVToJSON: (string) => Promise<Collection[]> = (
   path: string
@@ -19,7 +19,7 @@ export const convertCSVToJSON: (string) => Promise<Collection[]> = (
       .on("end", async () => {
         if (results.length > 0) {
           try {
-            const formattedCollections = validateAndSanitizeInput(results)
+            const formattedCollections = results.map(sanitizeRow)
             resolve(formattedCollections)
           } catch (e) {
             reject(e)

--- a/src/utils/processInput.ts
+++ b/src/utils/processInput.ts
@@ -1,41 +1,7 @@
 import slugify from "slugify"
 import { Collection, CollectionGroup, GroupType } from "../Entities"
 
-const validate = input => {
-  const by_slug = input.reduce((acc, val) => ({ ...acc, [val.slug]: true }), {})
-  const bad_slugs = new Set()
-
-  const process_link = slug_string =>
-    slug_string.split(",").forEach(slug => {
-      if (slug && !by_slug[slug]) {
-        bad_slugs.add(slug)
-      }
-    })
-
-  input.forEach(
-    ({ artist_series, featured_collections, other_collections }) => {
-      artist_series && process_link(artist_series)
-      featured_collections && process_link(featured_collections)
-      other_collections && process_link(other_collections)
-    }
-  )
-
-  return bad_slugs
-}
-
-export const validateAndSanitizeInput = rows => {
-  const bad_slugs = validate(rows)
-  console.log("Validation errors found:", bad_slugs.size)
-  if (bad_slugs.size > 0) {
-    throw new Error(
-      "Unable to resolve one or more linked slugs: " +
-        Array.from(bad_slugs).join(" | ")
-    )
-  }
-  return rows.map(sanitizeRow)
-}
-
-const sanitizeRow = ({
+export const sanitizeRow = ({
   title,
   slug,
   category,


### PR DESCRIPTION
This PR satisfies the requirements of [GROW-1512](https://artsyproduct.atlassian.net/browse/GROW-1512) by removing the core change put into place by [this PR](https://github.com/artsy/kaws/pull/137) a few weeks ago. After discussion with @l2succes we decided that validating in the way were were was not actually helping us very much but it was making the data ingestion procedure a bit more complicated than it had to be. This keeps the updates to the testing mocks which added resolving collection slugs, but no longer enforces them.

Diff Analysis: 
```
{
  "total_files_changed": 3,
  "test_files_changed": 0,
  "by_type": {
    "ts": 3
  }
}
```