### PR TITLE
[GROW-1399] ensure SSL for all requests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,6 +2,7 @@ NODE_ENV=test
 PORT=4000
 APP_NAME=kaws-test
 DD_APM_ENABLED=false
+APP_URL=https://foobar.com
 
 # Database auth
 MONGOHQ_URL=mongodb://localhost:27017/kaws-test

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { parse } from "mongodb-uri"
 import * as morgan from "morgan"
 import { Connection, createConnection } from "typeorm"
 import { databaseConfig } from "./config/database"
+import { ensureSSL } from "./lib/ensureSSL"
 import GSheetImportApp from "./Routes/GSheetImport"
 import { createSchema } from "./utils/createSchema"
 
@@ -70,6 +71,9 @@ async function bootstrap() {
 
     // Setup middleware
     app.use(morgan("combined"))
+
+    // Make sure we're using SSL
+    app.use(ensureSSL)
 
     // Setup endpoints
     app.get("/health", (req, res) => res.status(200).end())

--- a/src/lib/__tests__/ensureSSL.test.ts
+++ b/src/lib/__tests__/ensureSSL.test.ts
@@ -1,0 +1,32 @@
+import { ensureSSL } from "../ensureSSL"
+
+describe("Ensure SSL middleware", () => {
+  let req
+  let res
+  let next
+
+  beforeEach(() => {
+    req = { params: {}, logout: jest.fn(), url: "/terms" }
+    res = { redirect: jest.fn() }
+    next = jest.fn()
+  })
+
+  it("redirects normal http requests to https", () => {
+    req.protocol = "http:"
+
+    ensureSSL(req, res, next)
+    console.log("redirect:", res.redirect.mock.calls)
+    expect(res.redirect.mock.calls[0]).toEqual([
+      301,
+      "https://foobar.com/terms",
+    ])
+  })
+
+  it("does not redirect https protocols", () => {
+    req.protocol = "https:"
+
+    ensureSSL(req, res, next)
+    expect(res.redirect).not.toBeCalled()
+    expect(next).toBeCalled()
+  })
+})

--- a/src/lib/__tests__/ensureSSL.test.ts
+++ b/src/lib/__tests__/ensureSSL.test.ts
@@ -15,7 +15,6 @@ describe("Ensure SSL middleware", () => {
     req.protocol = "http:"
 
     ensureSSL(req, res, next)
-    console.log("redirect:", res.redirect.mock.calls)
     expect(res.redirect.mock.calls[0]).toEqual([
       301,
       "https://foobar.com/terms",

--- a/src/lib/ensureSSL.ts
+++ b/src/lib/ensureSSL.ts
@@ -1,0 +1,17 @@
+/*
+* Makes sure that any http requests get redirected to https
+*/
+
+import { parse } from "url"
+const { APP_URL } = process.env
+
+export const ensureSSL = (req, res, next) => {
+  const protocol = req.protocol
+  const isSecure = req.secure || protocol === "https:"
+
+  if (!isSecure && parse(APP_URL as string).protocol === "https:") {
+    res.redirect(301, APP_URL + req.url)
+  } else {
+    next()
+  }
+}


### PR DESCRIPTION
Addresses: [GROW-1399](https://artsyproduct.atlassian.net/browse/GROW-1399)

This ensures SSL for every request. This redirects to `https` when the request protocol isn't via https://.