### PR TITLE
@eessex => [Error Handling] Return a 404 in error extensions for non existent collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Master
 
+- Return `errors` with a 404 status code in `extensions` when a collection is
+  not found by slug [@mzikherman]
 - Adds ability to send collections to Sailthru w/ artist + artwork data [@mdole]
 - Return collections for an artist - [@mzikherman]
 - Enable text search - [@mzikherman]

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -73,7 +73,7 @@ export class CollectionsResolver {
 
   @Query(returns => Collection, { nullable: true })
   async collection(@Arg("slug") slug: string): Promise<Collection | undefined> {
-    return await this.repository.findOne({ slug })
+    return await this.repository.findOneOrFail({ slug })
   }
 
   @Query(returns => [Collection])

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
   mockedGetMongoRepository.mockReturnValue({
     aggregate: mockAggregate,
     find,
-    findOne: ({ slug }) =>
+    findOneOrFail: ({ slug }) =>
       mockCollectionRepository.find(
         (collection: Collection) => collection.slug === slug
       ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { Connection, createConnection } from "typeorm"
 import { databaseConfig } from "./config/database"
 import GSheetImportApp from "./Routes/GSheetImport"
 import { createSchema } from "./utils/createSchema"
+import { formatError } from "./utils/errorHandling"
 
 const enableSentry = Boolean(SENTRY_PRIVATE_DSN)
 
@@ -54,6 +55,7 @@ async function bootstrap() {
       endpoint: "/graphql",
       playground: "/playground",
       debug: NODE_ENV === "development",
+      formatError,
     }
 
     // Setup Sentry

--- a/src/utils/__tests__/errorHandling.test.ts
+++ b/src/utils/__tests__/errorHandling.test.ts
@@ -1,0 +1,20 @@
+import { GraphQLError } from "graphql"
+import { EntityNotFoundError } from "typeorm/error/EntityNotFoundError"
+import { formatError } from "../errorHandling"
+
+const originalError = new EntityNotFoundError("Collection", "test")
+const error = new GraphQLError(
+  "Collection Not Found",
+  undefined,
+  undefined,
+  undefined,
+  undefined,
+  originalError
+)
+
+describe(formatError, () => {
+  it("returns a 404 for EntityNotFound original errors", () => {
+    const errorWithExtension = formatError(error)
+    expect(errorWithExtension.extensions).toEqual({ code: 404 })
+  })
+})

--- a/src/utils/errorHandling.ts
+++ b/src/utils/errorHandling.ts
@@ -1,0 +1,25 @@
+import { GraphQLError, GraphQLFormattedError } from "graphql"
+import { EntityNotFoundError } from "typeorm/error/EntityNotFoundError"
+
+type WriteablePartial<T> = { -readonly [P in keyof T]+?: T[P] }
+
+export const formatError = (err: GraphQLError) => {
+  const result: WriteablePartial<GraphQLFormattedError> = {
+    message: err.message,
+  }
+
+  if (err.locations) {
+    result.locations = err.locations
+  }
+
+  if (err.path) {
+    result.path = err.path
+  }
+
+  const originalError = err.originalError
+  if (originalError instanceof EntityNotFoundError) {
+    result.extensions = { code: 404 }
+  }
+
+  return result
+}


### PR DESCRIPTION
Rather than silently fail to find a particular collection (https://www.artsy.net/collection/blah currently 500's, for instance), we now throw an appropriate error.

This gets the customary `errors` to show up in the response.

We then use some custom error formatting to decorate the error with a 404 if it's a 'not found' error. We should then be able to propagate this thru to Metaphysics and Reaction (and switch those 500's to 404's!).