### PR TITLE
remove await to prevent timeout, document google credential weirdness

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ collections you ask? A Collection is a prefiltered version of Artsy's
 - yarn 1.10.1 or newer
 - MongoDB 4.x
 
+## Note on Google API Access
+KAWS exposes an `/upload` endpoint meant to be invoked from a google sheet. In order for this process to work a few constraints have to hold:
+1. `GOOGLE_CLIENT_ID` must be set
+1. `GOOGLE_CLIENT_SECRET` must be set - this is a private key, and as such contains line-breaks. Those line-breaks must be represented in the .env file as simple `\n` characters!
+1. The client ID and client secret you're working with must be associated with a service account on google cloud. That service account's email address **must be invited as a participant in the document via the share button** or your credentials won't work.
+
 ## Getting started
 
 First, make sure to install dependencies:

--- a/src/Routes/GSheetImport.ts
+++ b/src/Routes/GSheetImport.ts
@@ -86,8 +86,14 @@ export const upload = async (
   })
 
   try {
-    await updateDatabase(rows)
-    res.send(200)
+    updateDatabase(rows)
+    res
+      .status(200)
+      .send(
+        `Updating ${
+          rows.length
+        } records in the database, please wait a few minutes!`
+      )
   } catch (e) {
     console.log("There was an error uploading collection data.")
     console.log(e.message)

--- a/src/Routes/__tests__/GSheetImport.test.ts
+++ b/src/Routes/__tests__/GSheetImport.test.ts
@@ -122,7 +122,10 @@ describe("GSheetImport", () => {
         },
       ])
 
-      expect(res.send).toBeCalledWith(200)
+      expect(res.status).toBeCalledWith(200)
+      expect(res.send).toBeCalledWith(
+        "Updating 3 records in the database, please wait a few minutes!"
+      )
     })
 
     it("responds with 500 if spreadsheetID is not in allowlist", async () => {

--- a/src/utils/updateDatabase.ts
+++ b/src/utils/updateDatabase.ts
@@ -26,6 +26,9 @@ export async function updateDatabase(collections: Collection[]) {
 
       console.log("Successfully updated collections database")
       connection.close()
+    } else {
+      console.log("connection.isConnected === false, throwing error!")
+      throw new Error("The database connection is not currently active!")
     }
   } catch (error) {
     console.error("[kaws] Error bootstrapping data:", error)

--- a/src/utils/updateDatabase.ts
+++ b/src/utils/updateDatabase.ts
@@ -17,8 +17,15 @@ export async function updateDatabase(collections: Collection[]) {
     if (connection.isConnected) {
       for (const entry of collections) {
         if (!entry.price_guidance) {
-          const priceGuidance = await getPriceGuidance(entry.slug)
-          extend(entry, { price_guidance: priceGuidance })
+          try {
+            const priceGuidance = await getPriceGuidance(entry.slug)
+            extend(entry, { price_guidance: priceGuidance })
+          } catch (e) {
+            console.log(
+              "[PriceGuidance] Unable to set price guidance on " + entry.slug
+            )
+            console.log(e.message)
+          }
         }
         await collection.update({ slug: entry.slug }, entry, { upsert: true })
         console.log("Successfully updated: ", entry.slug, entry.title)


### PR DESCRIPTION
Removes an 'await' that was causing timeouts on long bulk operations. Updates documentation.

Diff Analysis: 
```
{
  "total_files_changed": 2,
  "test_files_changed": 0,
  "by_type": {
    "ts": 1,
    "md": 1
  }
}
```
