### PR TITLE
Deprecate snake case names, introduce new camel case fields

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -70,32 +70,52 @@ type CollectionQuery {
   id: ID
   acquireable: Boolean
   aggregations: [String!]
-  artist_ids: [String!]
-  artist_id: String
-  at_auction: Boolean
+  artist_ids: [String!] @deprecated(reason: "Prefer artistIDs")
+  artistIDs: [String!]
+  artist_id: String @deprecated(reason: "Prefer artistID")
+  artistID: String
+  at_auction: Boolean @deprecated(reason: "Prefer atAuction")
+  atAuction: Boolean
   color: String
-  dimension_range: String
+  dimension_range: String @deprecated(reason: "Prefer dimensionRange")
+  dimensionRange: String
   extra_aggregation_gene_ids: [String!]
+    @deprecated(reason: "prefer extraAggregationGeneIDs")
+  extraAggregationGeneIDs: [String!]
   include_artworks_by_followed_artists: Boolean
+    @deprecated(reason: "Prefer includeArtworksByFollowedArtists")
+  includeArtworksByFollowedArtists: Boolean
   include_medium_filter_in_aggregation: Boolean
-  inquireable_only: Boolean
-  for_sale: Boolean
-  gene_id: String
-  gene_ids: [String!]
+    @deprecated(reason: "Prefer includeMediumFilterInAggregation")
+  includeMediumFilterInAggregation: Boolean
+  inquireable_only: Boolean @deprecated(reason: "Prefer inquireableOnly")
+  inquireableOnly: Boolean
+  for_sale: Boolean @deprecated(reason: "Prefer forSale")
+  forSale: Boolean
+  gene_id: String @deprecated(reason: "Prefer geneID")
+  geneID: String
+  gene_ids: [String!] @deprecated(reason: "Prefer geneIDs")
+  geneIDs: [String!]
   height: String
   width: String
   medium: String
   period: String
   periods: [String!]
-  major_periods: [String!]
-  partner_id: ID
-  partner_cities: [String!]
-  price_range: String
+  major_periods: [String!] @deprecated(reason: "Prefer majorPeriods")
+  majorPeriods: [String!]
+  partner_id: ID @deprecated(reason: "Prefer partnerID")
+  partnerID: ID
+  partner_cities: [String!] @deprecated(reason: "Prefer partnerCities")
+  partnerCities: [String!]
+  price_range: String @deprecated(reason: "Prefer priceRange")
+  priceRange: String
   page: Int
-  sale_id: ID
+  sale_id: ID @deprecated(reason: "Prefer saleID")
+  saleID: ID
   size: Int
   sort: String
-  tag_id: String
+  tag_id: String @deprecated(reason: "Prefer tagID")
+  tagID: String
   keyword: String
 }
 

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -32,13 +32,23 @@ type Collection {
   updatedAt: DateTime!
 
   # Suggested average price for included works
-  price_guidance: Float
+  price_guidance: Float @deprecated(reason: "Prefer priceGuidance")
+
+  # Suggested average price for included works
+  priceGuidance: Float
 
   # Collection can be surfaced on editorial pages
-  show_on_editorial: Boolean!
+  show_on_editorial: Boolean! @deprecated(reason: "Prefer showOnEditorial")
+
+  # Collection can be surfaced on editorial pages
+  showOnEditorial: Boolean!
 
   # Collection has prioritized connection to artist
   is_featured_artist_content: Boolean!
+    @deprecated(reason: "Prefer isFeaturedArtistContent")
+
+  # Collection has prioritized connection to artist
+  isFeaturedArtistContent: Boolean!
 
   # CollectionGroups of this collection
   linkedCollections: [CollectionGroup!]!

--- a/src/Entities/Collection.ts
+++ b/src/Entities/Collection.ts
@@ -79,21 +79,43 @@ export class Collection {
   @Field(type => Number, {
     nullable: true,
     description: "Suggested average price for included works",
+    deprecationReason: "Prefer priceGuidance",
   })
   @Column({ nullable: true })
   price_guidance: number | null = null
 
+  @Field(type => Number, {
+    nullable: true,
+    description: "Suggested average price for included works",
+  })
+  @Column({ name: "price_guidance", nullable: true })
+  priceGuidance: number | null = null
+
   @Field(type => Boolean, {
     description: "Collection can be surfaced on editorial pages",
+    deprecationReason: "Prefer showOnEditorial",
   })
   @Column({ default: false })
   show_on_editorial: boolean = false
 
   @Field(type => Boolean, {
+    description: "Collection can be surfaced on editorial pages",
+  })
+  @Column({ name: "show_on_editorial", default: false })
+  showOnEditorial: boolean = false
+
+  @Field(type => Boolean, {
     description: "Collection has prioritized connection to artist",
+    deprecationReason: "Prefer isFeaturedArtistContent",
   })
   @Column({ default: false })
   is_featured_artist_content: boolean = false
+
+  @Field(type => Boolean, {
+    description: "Collection has prioritized connection to artist",
+  })
+  @Column({ name: "is_featured_artist_content", default: false })
+  isFeaturedArtistContent: boolean = false
 
   @Field(type => [CollectionGroup], {
     description: "CollectionGroups of this collection",

--- a/src/Entities/CollectionQuery.ts
+++ b/src/Entities/CollectionQuery.ts
@@ -16,53 +16,117 @@ export class CollectionQuery {
   @Column({ nullable: true })
   aggregations?: string[] = []
 
-  @Field(type => [String], { nullable: true, description: "" })
+  @Field(type => [String], {
+    nullable: true,
+    description: "",
+    deprecationReason: "Prefer artistIDs",
+  })
   @Column({ nullable: true })
   artist_ids?: string[] = []
 
-  @Field({ nullable: true, description: "" })
+  @Field(type => [String], { nullable: true, description: "" })
+  @Column({ name: "artist_ids", nullable: true })
+  artistIDs?: string[] = []
+
+  @Field({
+    nullable: true,
+    description: "",
+    deprecationReason: "Prefer artistID",
+  })
   @Column({ nullable: true })
   artist_id?: string
 
-  @Field({ nullable: true })
+  @Field({ nullable: true, description: "" })
+  @Column({ name: "artist_id", nullable: true })
+  artistID?: string
+
+  @Field({ nullable: true, deprecationReason: "Prefer atAuction" })
   @Column({ nullable: true })
   at_auction?: boolean
+
+  @Field({ nullable: true })
+  @Column({ name: "at_auction", nullable: true })
+  atAuction?: boolean
 
   @Field({ nullable: true })
   @Column({ nullable: true })
   color?: string
 
-  @Field({ nullable: true })
+  @Field({ nullable: true, deprecationReason: "Prefer dimensionRange" })
   @Column({ nullable: true })
   dimension_range?: string
 
-  @Field(type => [String], { nullable: true })
+  @Field({ nullable: true })
+  @Column({ name: "dimension_range", nullable: true })
+  dimensionRange?: string
+
+  @Field(type => [String], {
+    nullable: true,
+    deprecationReason: "prefer extraAggregationGeneIDs",
+  })
   @Column({ nullable: true })
   extra_aggregation_gene_ids?: string[]
 
-  @Field({ nullable: true })
+  @Field(type => [String], { nullable: true })
+  @Column({ name: "extra_aggregation_gene_ids", nullable: true })
+  extraAggregationGeneIDs?: string[]
+
+  @Field({
+    nullable: true,
+    deprecationReason: "Prefer includeArtworksByFollowedArtists",
+  })
   @Column({ nullable: true })
   include_artworks_by_followed_artists?: boolean
 
   @Field({ nullable: true })
+  @Column({ name: "include_artworks_by_followed_artists", nullable: true })
+  includeArtworksByFollowedArtists?: boolean
+
+  @Field({
+    nullable: true,
+    deprecationReason: "Prefer includeMediumFilterInAggregation",
+  })
   @Column({ nullable: true })
   include_medium_filter_in_aggregation?: boolean
 
   @Field({ nullable: true })
+  @Column({ name: "include_medium_filter_in_aggregation", nullable: true })
+  includeMediumFilterInAggregation?: boolean
+
+  @Field({ nullable: true, deprecationReason: "Prefer inquireableOnly" })
   @Column({ nullable: true })
   inquireable_only?: boolean
 
   @Field({ nullable: true })
+  @Column({ name: "inquireable_only", nullable: true })
+  inquireableOnly?: boolean
+
+  @Field({ nullable: true, deprecationReason: "Prefer forSale" })
   @Column({ nullable: true })
   for_sale?: boolean
 
   @Field({ nullable: true })
+  @Column({ name: "for_sale", nullable: true })
+  forSale?: boolean
+
+  @Field({ nullable: true, deprecationReason: "Prefer geneID" })
   @Column({ nullable: true })
   gene_id?: string
 
-  @Field(type => [String], { nullable: true })
+  @Field({ nullable: true })
+  @Column({ name: "gene_id", nullable: true })
+  geneID?: string
+
+  @Field(type => [String], {
+    nullable: true,
+    deprecationReason: "Prefer geneIDs",
+  })
   @Column({ nullable: true })
   gene_ids?: string[] = []
+
+  @Field(type => [String], { nullable: true })
+  @Column({ name: "gene_ids", nullable: true })
+  geneIDs?: string[] = []
 
   @Field({ nullable: true })
   @Column({ nullable: true })
@@ -84,29 +148,55 @@ export class CollectionQuery {
   @Column({ nullable: true })
   periods?: string[]
 
-  @Field(type => [String], { nullable: true })
+  @Field(type => [String], {
+    nullable: true,
+    deprecationReason: "Prefer majorPeriods",
+  })
   @Column({ nullable: true })
   major_periods?: string[]
 
-  @Field(type => ID, { nullable: true })
+  @Field(type => [String], { nullable: true })
+  @Column({ name: "major_periods", nullable: true })
+  majorPeriods?: string[]
+
+  @Field(type => ID, { nullable: true, deprecationReason: "Prefer partnerID" })
   @Column({ nullable: true })
   partner_id?: string
 
-  @Field(type => [String], { nullable: true })
+  @Field(type => ID, { nullable: true })
+  @Column({ name: "partner_id", nullable: true })
+  partnerID?: string
+
+  @Field(type => [String], {
+    nullable: true,
+    deprecationReason: "Prefer partnerCities",
+  })
   @Column({ nullable: true })
   partner_cities?: string[]
 
-  @Field({ nullable: true })
+  @Field(type => [String], { nullable: true })
+  @Column({ name: "partner_cities", nullable: true })
+  partnerCities?: string[]
+
+  @Field({ nullable: true, deprecationReason: "Prefer priceRange" })
   @Column({ nullable: true })
   price_range?: string
+
+  @Field({ nullable: true })
+  @Column({ name: "price_range", nullable: true })
+  priceRange?: string
 
   @Field(type => Int, { nullable: true })
   @Column({ nullable: true })
   page?: number
 
-  @Field(type => ID, { nullable: true })
+  @Field(type => ID, { nullable: true, deprecationReason: "Prefer saleID" })
   @Column({ nullable: true })
   sale_id?: string
+
+  @Field(type => ID, { nullable: true })
+  @Column({ name: "sale_id", nullable: true })
+  saleID?: string
 
   @Field(type => Int, { nullable: true })
   @Column({ nullable: true })
@@ -116,9 +206,13 @@ export class CollectionQuery {
   @Column({ nullable: true })
   sort?: string
 
-  @Field({ nullable: true })
+  @Field({ nullable: true, deprecationReason: "Prefer tagID" })
   @Column({ nullable: true })
   tag_id?: string
+
+  @Field({ nullable: true })
+  @Column({ name: "tag_id", nullable: true })
+  tagID?: string
 
   @Field({ nullable: true })
   @Column({ nullable: true })

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -35,13 +35,22 @@ type Collection {
   updatedAt: DateTime!
 
   # Suggested average price for included works
-  price_guidance: Float
+  price_guidance: Float @deprecated(reason: \\"Prefer priceGuidance\\")
+
+  # Suggested average price for included works
+  priceGuidance: Float
 
   # Collection can be surfaced on editorial pages
-  show_on_editorial: Boolean!
+  show_on_editorial: Boolean! @deprecated(reason: \\"Prefer showOnEditorial\\")
+
+  # Collection can be surfaced on editorial pages
+  showOnEditorial: Boolean!
 
   # Collection has prioritized connection to artist
-  is_featured_artist_content: Boolean!
+  is_featured_artist_content: Boolean! @deprecated(reason: \\"Prefer isFeaturedArtistContent\\")
+
+  # Collection has prioritized connection to artist
+  isFeaturedArtistContent: Boolean!
 
   # CollectionGroups of this collection
   linkedCollections: [CollectionGroup!]!
@@ -63,32 +72,49 @@ type CollectionQuery {
   id: ID
   acquireable: Boolean
   aggregations: [String!]
-  artist_ids: [String!]
-  artist_id: String
-  at_auction: Boolean
+  artist_ids: [String!] @deprecated(reason: \\"Prefer artistIDs\\")
+  artistIDs: [String!]
+  artist_id: String @deprecated(reason: \\"Prefer artistID\\")
+  artistID: String
+  at_auction: Boolean @deprecated(reason: \\"Prefer atAuction\\")
+  atAuction: Boolean
   color: String
-  dimension_range: String
-  extra_aggregation_gene_ids: [String!]
-  include_artworks_by_followed_artists: Boolean
-  include_medium_filter_in_aggregation: Boolean
-  inquireable_only: Boolean
-  for_sale: Boolean
-  gene_id: String
-  gene_ids: [String!]
+  dimension_range: String @deprecated(reason: \\"Prefer dimensionRange\\")
+  dimensionRange: String
+  extra_aggregation_gene_ids: [String!] @deprecated(reason: \\"prefer extraAggregationGeneIDs\\")
+  extraAggregationGeneIDs: [String!]
+  include_artworks_by_followed_artists: Boolean @deprecated(reason: \\"Prefer includeArtworksByFollowedArtists\\")
+  includeArtworksByFollowedArtists: Boolean
+  include_medium_filter_in_aggregation: Boolean @deprecated(reason: \\"Prefer includeMediumFilterInAggregation\\")
+  includeMediumFilterInAggregation: Boolean
+  inquireable_only: Boolean @deprecated(reason: \\"Prefer inquireableOnly\\")
+  inquireableOnly: Boolean
+  for_sale: Boolean @deprecated(reason: \\"Prefer forSale\\")
+  forSale: Boolean
+  gene_id: String @deprecated(reason: \\"Prefer geneID\\")
+  geneID: String
+  gene_ids: [String!] @deprecated(reason: \\"Prefer geneIDs\\")
+  geneIDs: [String!]
   height: String
   width: String
   medium: String
   period: String
   periods: [String!]
-  major_periods: [String!]
-  partner_id: ID
-  partner_cities: [String!]
-  price_range: String
+  major_periods: [String!] @deprecated(reason: \\"Prefer majorPeriods\\")
+  majorPeriods: [String!]
+  partner_id: ID @deprecated(reason: \\"Prefer partnerID\\")
+  partnerID: ID
+  partner_cities: [String!] @deprecated(reason: \\"Prefer partnerCities\\")
+  partnerCities: [String!]
+  price_range: String @deprecated(reason: \\"Prefer priceRange\\")
+  priceRange: String
   page: Int
-  sale_id: ID
+  sale_id: ID @deprecated(reason: \\"Prefer saleID\\")
+  saleID: ID
   size: Int
   sort: String
-  tag_id: String
+  tag_id: String @deprecated(reason: \\"Prefer tagID\\")
+  tagID: String
   keyword: String
 }
 


### PR DESCRIPTION
This is part of the metaphysics v2 migration as tracked by PLATFORM-1661. 

Part of the effort of MPv2 is to reduce consistencies in our gql field namings. A big push was done for metaphysics to remove all camel cased fields. This is a continuation of that effort. 

This PR doesn't introduce a breaking change. You can see more about the updates below. 

<details>

<summary>Overview of changes</summary>

##

Generated by [`graphql-inspector`](https://github.com/kamilkisiela/graphql-inspector)

```
Detected the following changes (60) between schemas:

✔ Field priceGuidance was added to object type Collection
✔ Field showOnEditorial was added to object type Collection
✔ Field isFeaturedArtistContent was added to object type Collection
✔ Field Collection.price_guidance is deprecated
✔ Field Collection.price_guidance has deprecation reason Prefer priceGuidance
✔ Field Collection.show_on_editorial is deprecated
✔ Field Collection.show_on_editorial has deprecation reason Prefer showOnEditorial
✔ Field Collection.is_featured_artist_content is deprecated
✔ Field Collection.is_featured_artist_content has deprecation reason Prefer isFeaturedArtistContent
✔ Field artistIDs was added to object type CollectionQuery
✔ Field artistID was added to object type CollectionQuery
✔ Field atAuction was added to object type CollectionQuery
✔ Field dimensionRange was added to object type CollectionQuery
✔ Field extraAggregationGeneIDs was added to object type CollectionQuery
✔ Field includeArtworksByFollowedArtists was added to object type CollectionQuery
✔ Field includeMediumFilterInAggregation was added to object type CollectionQuery
✔ Field inquireableOnly was added to object type CollectionQuery
✔ Field forSale was added to object type CollectionQuery
✔ Field geneID was added to object type CollectionQuery
✔ Field geneIDs was added to object type CollectionQuery
✔ Field majorPeriods was added to object type CollectionQuery
✔ Field partnerID was added to object type CollectionQuery
✔ Field partnerCities was added to object type CollectionQuery
✔ Field priceRange was added to object type CollectionQuery
✔ Field saleID was added to object type CollectionQuery
✔ Field tagID was added to object type CollectionQuery
✔ Field CollectionQuery.artist_ids is deprecated
✔ Field CollectionQuery.artist_ids has deprecation reason Prefer artistIDs
✔ Field CollectionQuery.artist_id is deprecated
✔ Field CollectionQuery.artist_id has deprecation reason Prefer artistID
✔ Field CollectionQuery.at_auction is deprecated
✔ Field CollectionQuery.at_auction has deprecation reason Prefer atAuction
✔ Field CollectionQuery.dimension_range is deprecated
✔ Field CollectionQuery.dimension_range has deprecation reason Prefer dimensionRange
✔ Field CollectionQuery.extra_aggregation_gene_ids is deprecated
✔ Field CollectionQuery.extra_aggregation_gene_ids has deprecation reason prefer extraAggregationGeneIDs
✔ Field CollectionQuery.include_artworks_by_followed_artists is deprecated
✔ Field CollectionQuery.include_artworks_by_followed_artists has deprecation reason Prefer includeArtworksByFollowedArtists
✔ Field CollectionQuery.include_medium_filter_in_aggregation is deprecated
✔ Field CollectionQuery.include_medium_filter_in_aggregation has deprecation reason Prefer includeMediumFilterInAggregation
✔ Field CollectionQuery.inquireable_only is deprecated
✔ Field CollectionQuery.inquireable_only has deprecation reason Prefer inquireableOnly
✔ Field CollectionQuery.for_sale is deprecated
✔ Field CollectionQuery.for_sale has deprecation reason Prefer forSale
✔ Field CollectionQuery.gene_id is deprecated
✔ Field CollectionQuery.gene_id has deprecation reason Prefer geneID
✔ Field CollectionQuery.gene_ids is deprecated
✔ Field CollectionQuery.gene_ids has deprecation reason Prefer geneIDs
✔ Field CollectionQuery.major_periods is deprecated
✔ Field CollectionQuery.major_periods has deprecation reason Prefer majorPeriods
✔ Field CollectionQuery.partner_id is deprecated
✔ Field CollectionQuery.partner_id has deprecation reason Prefer partnerID
✔ Field CollectionQuery.partner_cities is deprecated
✔ Field CollectionQuery.partner_cities has deprecation reason Prefer partnerCities
✔ Field CollectionQuery.price_range is deprecated
✔ Field CollectionQuery.price_range has deprecation reason Prefer priceRange
✔ Field CollectionQuery.sale_id is deprecated
✔ Field CollectionQuery.sale_id has deprecation reason Prefer saleID
✔ Field CollectionQuery.tag_id is deprecated
✔ Field CollectionQuery.tag_id has deprecation reason Prefer tagID
```

##

</details>

I'm _not_ certain of all the implications of this change, so I'll definitely lean on folks there. Is this a bad idea?