### PR TITLE
Add internalID fields to kaws schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -52,6 +52,7 @@ type CollectionCategory {
 }
 
 type CollectionGroup {
+  internalID: ID
   groupType: GroupTypes!
   name: String!
   members: [Collection!]!

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1,6 +1,7 @@
 # Object representing a collection page
 type Collection {
   id: ID!
+  internalID: ID!
 
   # slug version of title, used for pretty URLs (e.g. `kaws-prints` for Kaws Prints
   slug: String!
@@ -58,6 +59,7 @@ type CollectionGroup {
 
 type CollectionQuery {
   id: ID
+  internalID: ID
   acquireable: Boolean
   aggregations: [String!]
   artist_ids: [String!]

--- a/src/Entities/Collection.ts
+++ b/src/Entities/Collection.ts
@@ -10,6 +10,10 @@ export class Collection {
   @ObjectIdColumn()
   id: ObjectID
 
+  @Field(type => ID)
+  @ObjectIdColumn({ name: "id" })
+  internalID: ObjectID
+
   @Index({ unique: true })
   @Field({
     description:

--- a/src/Entities/CollectionGroup.ts
+++ b/src/Entities/CollectionGroup.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType, registerEnumType } from "type-graphql"
+import { Field, ID, ObjectType, registerEnumType } from "type-graphql"
 import { Column, Entity, ObjectID, ObjectIdColumn } from "typeorm"
 import { Collection } from "./Collection"
 
@@ -19,6 +19,7 @@ export class CollectionGroup {
   @ObjectIdColumn()
   id: ObjectID
 
+  @Field(type => ID, { nullable: true })
   @ObjectIdColumn({ name: "id" })
   internalID: ObjectID
 

--- a/src/Entities/CollectionGroup.ts
+++ b/src/Entities/CollectionGroup.ts
@@ -19,6 +19,9 @@ export class CollectionGroup {
   @ObjectIdColumn()
   id: ObjectID
 
+  @ObjectIdColumn({ name: "id" })
+  internalID: ObjectID
+
   @Field(type => GroupType)
   @Column()
   groupType: GroupType

--- a/src/Entities/CollectionQuery.ts
+++ b/src/Entities/CollectionQuery.ts
@@ -8,6 +8,10 @@ export class CollectionQuery {
   @ObjectIdColumn()
   id: ObjectID
 
+  @Field(type => ID, { nullable: true })
+  @ObjectIdColumn({ name: "id" })
+  internalID: ObjectID
+
   @Field({ nullable: true, description: "" })
   @Column({ nullable: true })
   acquireable?: boolean

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -4,6 +4,7 @@ exports[`creates an SDL 1`] = `
 "# Object representing a collection page
 type Collection {
   id: ID!
+  internalID: ID!
 
   # slug version of title, used for pretty URLs (e.g. \`kaws-prints\` for Kaws Prints 
   slug: String!
@@ -61,6 +62,7 @@ type CollectionGroup {
 
 type CollectionQuery {
   id: ID
+  internalID: ID
   acquireable: Boolean
   aggregations: [String!]
   artist_ids: [String!]

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -55,6 +55,7 @@ type CollectionCategory {
 }
 
 type CollectionGroup {
+  internalID: ID
   groupType: GroupTypes!
   name: String!
   members: [Collection!]!


### PR DESCRIPTION
This addresses PLATFORM-1673

In MPv2 the semantics of handling ids has changed. We've added a field called `internalID` to all services that reference whatever the database id for that system might be. The specifics of that id is considered special to the system providing it. 

This is an additive change to the schema to duplicate the `id` fields into an `internalID` field. 

From graphql-inspector: 

```
Detected the following changes (3) between schemas:

✔ Field internalID was added to object type Collection
✔ Field internalID was added to object type CollectionQuery
✔ Field internalID was added to object type CollectionGroup
```