### PR TITLE
fixes some issues with price guidance

### DIFF
--- a/src/__tests__/collectionHubs.test.ts
+++ b/src/__tests__/collectionHubs.test.ts
@@ -83,11 +83,9 @@ describe("CollectionHubs", () => {
 
   it("returns a list of collectionHub instances where the slug is equal to one of the selected hub slugs.", async () => {
     const foundCollections = await collectionRepository.find()
-    hub_slugs.forEach(root_slug => {
-      expect(
-        foundCollections.map(({ slug }) => slug).indexOf(root_slug)
-      ).not.toBe(-1)
-    })
+    const returnedSlugs = foundCollections.map(({ slug }) => slug)
+
+    expect(returnedSlugs).toEqual(expect.arrayContaining(hub_slugs))
   })
 
   it("respects graphql top-level query", async () => {

--- a/src/__tests__/collectionHubs.test.ts
+++ b/src/__tests__/collectionHubs.test.ts
@@ -83,7 +83,11 @@ describe("CollectionHubs", () => {
 
   it("returns a list of collectionHub instances where the slug is equal to one of the selected hub slugs.", async () => {
     const foundCollections = await collectionRepository.find()
-    expect(foundCollections.length).toBe(6)
+    hub_slugs.forEach(root_slug => {
+      expect(
+        foundCollections.map(({ slug }) => slug).indexOf(root_slug)
+      ).not.toBe(-1)
+    })
   })
 
   it("respects graphql top-level query", async () => {

--- a/src/__tests__/price_guidance_integration.test.ts
+++ b/src/__tests__/price_guidance_integration.test.ts
@@ -1,0 +1,112 @@
+jest.mock("../utils/getPriceGuidance")
+import { getPriceGuidance } from "../utils/getPriceGuidance"
+;(getPriceGuidance as any).mockResolvedValue(1000)
+
+import { Connection, createConnection, MongoRepository } from "typeorm"
+import { databaseConfig } from "../config/database"
+import { Collection } from "../Entities"
+import { updateDatabase } from "../utils/updateDatabase"
+
+const hub_slugs = [
+  "contemporary",
+  "post-war",
+  "impressionist-and-modern",
+  "pre-20th-century",
+  "photography",
+  "street-art",
+]
+const PGs = [100, 100, 100, 100, 200, null]
+const generateMockData = () => {
+  return hub_slugs.map((slug, index) => {
+    return {
+      title: "Pablo Picasso: Portraits",
+      slug,
+      category: "Modern",
+      description:
+        '<p>Although Pablo Picasso worked in a variety of different styles and mediums throughout his prolific career, he never stopped creating portraits of those in his inner circle. Even in his most abstract portraits, Picasso captures his sitters’ personalities. For example, his cubist portrait of his friend and art dealer <i><a href="https://www.artsy.net/artwork/pablo-picasso-portrait-of-art-dealer-ambroise-vollard-1867-1939">Ambroise Vollard</a></i> (1910), shows the figure broken down into geometric, angled shapes, although the viewer can still discover that Vollard was a serious and somewhat gruff individual with his downcast eyes and frown. Picasso is also famous for his portraits of his lovers, which often distort their features into playful abstractions. His sultry sleeping portrait of Marie-Thérèse Walter, <i>Le Rêve</i> (1932) is among the world’s most expensive paintings ever sold, reaching $155 million through a private sale in 2013. Regarding his outlook on portraiture, Picasso was often elusive. “When you start with a portrait and search for a pure form, a clear volume, through successive eliminations, you arrive inevitably at the egg,” he once said, “Likewise, starting with the egg and following the same process in reverse, one finishes with the portrait.”</p>',
+      headerImage: "http://files.artsy.net/images/picasso-portraits.png",
+      credit:
+        "<p>&copy; Pablo Picasso / Artist Rights Society (ARS), New York, NY.</p>",
+      query: {
+        artist_ids: ["4d8b928b4eb68a1b2c0001f2"],
+        gene_ids: ["portrait"],
+        tag_id: "",
+        keyword: "",
+      },
+      price_guidance: PGs[index],
+    }
+  })
+}
+
+describe("priceGuidance", () => {
+  let connection: Connection
+  let repo: MongoRepository<Collection>
+  let data: Collection[]
+  let models: Collection[]
+
+  const openDatabaseConnection = async () => {
+    const connectionArgs = databaseConfig()
+    return createConnection(connectionArgs)
+  }
+
+  const getRepo = async activeConnection => {
+    const repository = await activeConnection.getMongoRepository(Collection)
+    await repository.clear()
+    return repository
+  }
+
+  const seedData = async () => {
+    data = generateMockData() as Collection[]
+    await updateDatabase(data)
+    return data
+  }
+
+  beforeAll(async () => {
+    connection = await openDatabaseConnection()
+    repo = await getRepo(connection)
+    data = await seedData()
+    models = await repo.find()
+  })
+
+  afterAll(async () => {
+    try {
+      await connection.close()
+    } catch (e) {
+      console.warn(e.message)
+    }
+  })
+
+  it("respects manually specified price guidance values", () => {
+    hub_slugs.forEach((_item, index) => {
+      const model = models[index]
+      const expected_value = PGs[index] || 1000
+      expect(model.priceGuidance).toBe(expected_value)
+    })
+  })
+
+  it("automatically looks up and tries to populate price guidance on those records where it was null", () => {
+    // it didn't try to set price guidance on 1-5, which specified overrides
+    expect(getPriceGuidance).not.toHaveBeenCalledWith(models[0].slug)
+    expect(getPriceGuidance).not.toHaveBeenCalledWith(models[1].slug)
+    expect(getPriceGuidance).not.toHaveBeenCalledWith(models[2].slug)
+    expect(getPriceGuidance).not.toHaveBeenCalledWith(models[3].slug)
+    expect(getPriceGuidance).not.toHaveBeenCalledWith(models[4].slug)
+
+    // record 6 had a null price guidance, so this was invoked.
+    expect(getPriceGuidance).toHaveBeenCalledWith(models[5].slug)
+  })
+
+  it("changing an override value is reflected in the data", async () => {
+    const update = { ...models[0], price_guidance: 20000 }
+    await updateDatabase([update])
+    const updated_models = await repo.find()
+    expect(updated_models[0].priceGuidance).toBe(20000) // new override
+  })
+
+  it("erases price guidance override if input specifies `null`, falling back to generated value", async () => {
+    const update = { ...models[0], price_guidance: null }
+    await updateDatabase([update])
+    const updated_models = await repo.find()
+    expect(updated_models[0].priceGuidance).toBe(1000) // computed value
+  })
+})

--- a/src/__tests__/price_guidance_integration.test.ts
+++ b/src/__tests__/price_guidance_integration.test.ts
@@ -46,12 +46,17 @@ describe("priceGuidance", () => {
 
   const openDatabaseConnection = async () => {
     const connectionArgs = databaseConfig()
-    return createConnection(connectionArgs)
+    return await createConnection(connectionArgs)
   }
 
   const getRepo = async activeConnection => {
     const repository = await activeConnection.getMongoRepository(Collection)
-    await repository.clear()
+    try {
+      await repository.clear()
+    } catch (e) {
+      // no worries if this fails, just means it's the first time it ran
+    }
+
     return repository
   }
 

--- a/src/utils/__tests__/getPriceGuidance.test.ts
+++ b/src/utils/__tests__/getPriceGuidance.test.ts
@@ -14,41 +14,45 @@ describe("#getPriceGuidance", () => {
     const results = {
       marketingCollection: {
         artworks: {
-          hits: [
-            {
-              priceCents: {
-                min: 22500,
-                max: 22500,
-              },
-            },
-            {
-              priceCents: {
-                min: 22500,
-                max: 22500,
-              },
-            },
-            {
-              priceCents: {
-                min: 29500,
-                max: 29500,
-              },
-            },
-            {
-              priceCents: {
-                min: 35000,
-                max: 35000,
-              },
-            },
-            {
-              priceCents: {
-                min: 36000,
-                max: 36000,
-              },
-            },
-          ],
-        },
+          artworks_connection: {
+            edges:
+              [
+                {
+                  priceCents: {
+                    min: 22500,
+                    max: 22500,
+                  },
+                },
+                {
+                  priceCents: {
+                    min: 22500,
+                    max: 22500,
+                  },
+                },
+                {
+                  priceCents: {
+                    min: 29500,
+                    max: 29500,
+                  },
+                },
+                {
+                  priceCents: {
+                    min: 35000,
+                    max: 35000,
+                  },
+                },
+                {
+                  priceCents: {
+                    min: 36000,
+                    max: 36000,
+                  },
+                }
+              ]
+          }
+        }
       },
     }
+
 
     mockMetaphysics.mockResolvedValue(results)
     const avgPrice = await getPriceGuidance("kaws-companions")
@@ -61,7 +65,7 @@ describe("#getPriceGuidance", () => {
     const results = {
       marketingCollection: {
         artworks: {
-          hits: [],
+          artworks_connection: { edges: [] },
         },
       },
     }
@@ -79,32 +83,34 @@ describe("#getPriceGuidance", () => {
     const results = {
       marketingCollection: {
         artworks: {
-          hits: [
-            {
-              priceCents: {
-                min: 22500,
-                max: 22500,
+          artworks_connection: {
+            edges: [
+              {
+                priceCents: {
+                  min: 22500,
+                  max: 22500,
+                },
               },
-            },
-            {
-              priceCents: {
-                min: 22500,
-                max: 22500,
+              {
+                priceCents: {
+                  min: 22500,
+                  max: 22500,
+                },
               },
-            },
-            {
-              priceCents: null,
-            },
-            {
-              priceCents: {
-                min: 35000,
-                max: 35000,
+              {
+                priceCents: null,
               },
-            },
-            {
-              priceCents: null,
-            },
-          ],
+              {
+                priceCents: {
+                  min: 35000,
+                  max: 35000,
+                },
+              },
+              {
+                priceCents: null,
+              },
+            ],
+          },
         },
       },
     }
@@ -120,26 +126,28 @@ describe("#getPriceGuidance", () => {
     const results = {
       marketingCollection: {
         artworks: {
-          hits: [
-            {
-              priceCents: {
-                min: 22500,
-                max: 22500,
+          artworks_connection: {
+            edges: [
+              {
+                priceCents: {
+                  min: 22500,
+                  max: 22500,
+                },
               },
-            },
-            {
-              priceCents: {
-                min: 22500,
-                max: 22500,
+              {
+                priceCents: {
+                  min: 22500,
+                  max: 22500,
+                },
               },
-            },
-            {
-              priceCents: {
-                min: 35000,
-                max: 35000,
+              {
+                priceCents: {
+                  min: 35000,
+                  max: 35000,
+                },
               },
-            },
-          ],
+            ],
+          }
         },
       },
     }

--- a/src/utils/__tests__/getPriceGuidance.test.ts
+++ b/src/utils/__tests__/getPriceGuidance.test.ts
@@ -15,44 +15,52 @@ describe("#getPriceGuidance", () => {
       marketingCollection: {
         artworks: {
           artworks_connection: {
-            edges:
-              [
-                {
+            edges: [
+              {
+                node: {
                   priceCents: {
                     min: 22500,
                     max: 22500,
                   },
                 },
-                {
+              },
+              {
+                node: {
                   priceCents: {
                     min: 22500,
                     max: 22500,
                   },
                 },
-                {
+              },
+              {
+                node: {
                   priceCents: {
                     min: 29500,
                     max: 29500,
                   },
                 },
-                {
+              },
+              {
+                node: {
                   priceCents: {
                     min: 35000,
                     max: 35000,
                   },
                 },
-                {
+              },
+              {
+                node: {
                   priceCents: {
                     min: 36000,
                     max: 36000,
                   },
-                }
-              ]
-          }
-        }
+                },
+              },
+            ],
+          },
+        },
       },
     }
-
 
     mockMetaphysics.mockResolvedValue(results)
     const avgPrice = await getPriceGuidance("kaws-companions")
@@ -86,28 +94,38 @@ describe("#getPriceGuidance", () => {
           artworks_connection: {
             edges: [
               {
-                priceCents: {
-                  min: 22500,
-                  max: 22500,
+                node: {
+                  priceCents: {
+                    min: 22500,
+                    max: 22500,
+                  },
                 },
               },
               {
-                priceCents: {
-                  min: 22500,
-                  max: 22500,
+                node: {
+                  priceCents: {
+                    min: 22500,
+                    max: 22500,
+                  },
                 },
               },
               {
-                priceCents: null,
-              },
-              {
-                priceCents: {
-                  min: 35000,
-                  max: 35000,
+                node: {
+                  priceCents: null,
                 },
               },
               {
-                priceCents: null,
+                node: {
+                  priceCents: {
+                    min: 35000,
+                    max: 35000,
+                  },
+                },
+              },
+              {
+                node: {
+                  priceCents: null,
+                },
               },
             ],
           },
@@ -129,25 +147,31 @@ describe("#getPriceGuidance", () => {
           artworks_connection: {
             edges: [
               {
-                priceCents: {
-                  min: 22500,
-                  max: 22500,
+                node: {
+                  priceCents: {
+                    min: 22500,
+                    max: 22500,
+                  },
                 },
               },
               {
-                priceCents: {
-                  min: 22500,
-                  max: 22500,
+                node: {
+                  priceCents: {
+                    min: 22500,
+                    max: 22500,
+                  },
                 },
               },
               {
-                priceCents: {
-                  min: 35000,
-                  max: 35000,
+                node: {
+                  priceCents: {
+                    min: 35000,
+                    max: 35000,
+                  },
                 },
               },
             ],
-          }
+          },
         },
       },
     }

--- a/src/utils/getPriceGuidance.ts
+++ b/src/utils/getPriceGuidance.ts
@@ -36,10 +36,11 @@ export const getPriceGuidance = async (slug: string) => {
     }`)
     let avgPrice
     let hasNoBasePrice
+
     const collectionPricesInDollars = flatMap(
       results.marketingCollection.artworks.artworks_connection.edges,
-      artwork => {
-        return getPriceInDollars(artwork.priceCents)
+      ({ node }) => {
+        return getPriceInDollars(node.priceCents)
       }
     ).filter(Boolean)
 

--- a/src/utils/getPriceGuidance.ts
+++ b/src/utils/getPriceGuidance.ts
@@ -15,16 +15,20 @@ export const getPriceGuidance = async (slug: string) => {
   try {
     const results: any = await metaphysics(`{
       marketingCollection(slug: "${slug}") {
-        artworks(
-          size: 5,
-          sort: "prices",
-          price_range: "10-*"
-        ) { 
-          hits {
-            price
-            priceCents {
-              min
-              max
+        artworks(aggregations: [TOTAL], price_range: "10-*", sort: "-has_price,-prices") {
+          artworks_connection(first: 5) {
+            edges {
+              node {
+                artist {
+                  name
+                }
+                title
+                price
+                priceCents {
+                  min
+                  max
+                }
+              }
             }
           }
         }
@@ -33,7 +37,7 @@ export const getPriceGuidance = async (slug: string) => {
     let avgPrice
     let hasNoBasePrice
     const collectionPricesInDollars = flatMap(
-      results.marketingCollection.artworks.hits,
+      results.marketingCollection.artworks.artworks_connection.edges,
       artwork => {
         return getPriceInDollars(artwork.priceCents)
       }


### PR DESCRIPTION
This is a doozy! Building on the research that @anandaroop did when he wrote up [GROW-1570](https://artsyproduct.atlassian.net/browse/GROW-1570) and [GROW-1571](https://artsyproduct.atlassian.net/browse/GROW-1571), my initial approach was going to be to decouple price guidance computation from ingestion and migrate it to a background task or cron job.

However, because of the way we're using the spreadsheet for user input we're in a bit of a pickle because uploading a row with an empty cell MAY mean "compute a default value", but it may also "replace the prior override with a computed default value", and sometimes the default value is still `null`.

So the thinking here is: whenever a sheet is uploaded and has a value for `priceGuidance`, great. We set that value and move on with our lives.

However, if any rows in that sheet don't have a priceGuidance specified we write a `null` to the database for that field. We then, once everything has been loaded, do a second pass where we search for all collections with `null` price guidance and we try to update each of them with correct data if we can generate it. 

I *think* the tests cover all the bases. Some takeaways from this: `TypeORM` is the ORM we are using in this repo, and (I think) we use it to generate the GraphQL schemas that we pipe out to Metaphysics. In this case, we've recently deprecated snake_case variable names - so the `Collection` entity in `TypeORM` has a property called `priceGuidance`, but the **backing field in the database** is still called `price_guidance`.

This would be no big deal if we consistently used TypeORM for our database operations, but we don't - our upload behavior is driven directly through the MongoDB driver and sidesteps the ORM entirely. Debugging that was a bit of a pain in the butt! :)

Diff Analysis: 
```
{
  "total_files_changed": 5,
  "test_files_changed": 3,
  "by_type": {
    "ts": 5
  }
}
```