### PR TITLE
Adds marketable field to kaws schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -106,6 +106,9 @@ type CollectionQuery {
   periods: [String!]
   major_periods: [String!] @deprecated(reason: "Prefer majorPeriods")
   majorPeriods: [String!]
+
+  # True for works that are not nude or provocative
+  marketable: Boolean
   partner_id: ID @deprecated(reason: "Prefer partnerID")
   partnerID: ID
   partner_cities: [String!] @deprecated(reason: "Prefer partnerCities")

--- a/src/Entities/CollectionQuery.ts
+++ b/src/Entities/CollectionQuery.ts
@@ -163,6 +163,13 @@ export class CollectionQuery {
   @Column({ name: "major_periods", nullable: true })
   majorPeriods?: string[]
 
+  @Field({
+    nullable: true,
+    description: "True for works that are not nude or provocative",
+  })
+  @Column({ nullable: true })
+  marketable?: boolean
+
   @Field(type => ID, { nullable: true, deprecationReason: "Prefer partnerID" })
   @Column({ nullable: true })
   partner_id?: string

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -105,6 +105,9 @@ type CollectionQuery {
   periods: [String!]
   major_periods: [String!] @deprecated(reason: \\"Prefer majorPeriods\\")
   majorPeriods: [String!]
+
+  # True for works that are not nude or provocative
+  marketable: Boolean
   partner_id: ID @deprecated(reason: \\"Prefer partnerID\\")
   partnerID: ID
   partner_cities: [String!] @deprecated(reason: \\"Prefer partnerCities\\")


### PR DESCRIPTION
This PR exposes the `marketable` field in Kaws to handle a check needed for GROW-1594.


[Links to GROW-1594](https://artsyproduct.atlassian.net/browse/GROW-1594)