### PR TITLE
Add featured_artist_exclusion_ids column to exclude artists from feat…

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -53,6 +53,9 @@ type Collection {
 
   # CollectionGroups of this collection
   linkedCollections: [CollectionGroup!]!
+
+  # IDs of artists that should be excluded from Featured Artists for this collection
+  featuredArtistExclusionIds: [String!]
   relatedCollections: [Collection!]!
 }
 

--- a/src/Entities/Collection.ts
+++ b/src/Entities/Collection.ts
@@ -126,4 +126,12 @@ export class Collection {
   })
   @Column(type => CollectionGroup)
   linkedCollections: CollectionGroup[]
+
+  @Field(type => [String], {
+    description:
+      "IDs of artists that should be excluded from Featured Artists for this collection",
+    nullable: true,
+  })
+  @Column({ nullable: true })
+  featuredArtistExclusionIds?: string[] = []
 }

--- a/src/Routes/GSheetImport.ts
+++ b/src/Routes/GSheetImport.ts
@@ -59,6 +59,7 @@ export const upload = async (
       featured_collections,
       other_collections_label,
       other_collections,
+      featured_artist_exclusion_ids,
     ] = row
 
     return sanitizeRow({
@@ -82,6 +83,7 @@ export const upload = async (
       featured_collections,
       other_collections_label,
       other_collections,
+      featured_artist_exclusion_ids,
     })
   })
 

--- a/src/Routes/__tests__/GSheetImport.test.ts
+++ b/src/Routes/__tests__/GSheetImport.test.ts
@@ -66,6 +66,7 @@ describe("GSheetImport", () => {
             keyword: "Superman",
           },
           linkedCollections: [],
+          featuredArtistExclusionIds: [],
         },
         {
           title: "Anish Kapoor: Etchings",
@@ -86,6 +87,7 @@ describe("GSheetImport", () => {
             gene_ids: ["etching-slash-engraving"],
           },
           linkedCollections: [],
+          featuredArtistExclusionIds: [],
         },
         {
           title: "Ansel Adams: Yosemite",
@@ -119,6 +121,7 @@ describe("GSheetImport", () => {
               groupType: GroupType.OtherCollections,
             },
           ],
+          featuredArtistExclusionIds: ["artist-id-for-pablo-picasso"],
         },
       ])
 
@@ -164,6 +167,7 @@ const rows = [
     "featured_collections",
     "other_collections_label",
     "other_collections",
+    "featured_artist_exclusion_ids",
   ],
   [
     "Andy Warhol: Superman",
@@ -210,5 +214,6 @@ const rows = [
     "",
     "OTHER",
     "andy-warhol-superman",
+    "artist-id-for-pablo-picasso",
   ],
 ]

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -55,6 +55,9 @@ type Collection {
 
   # CollectionGroups of this collection
   linkedCollections: [CollectionGroup!]!
+
+  # IDs of artists that should be excluded from Featured Artists for this collection
+  featuredArtistExclusionIds: [String!]
   relatedCollections: [Collection!]!
 }
 

--- a/src/utils/processInput.ts
+++ b/src/utils/processInput.ts
@@ -22,6 +22,7 @@ export const sanitizeRow = ({
   featured_collections,
   other_collections_label,
   other_collections,
+  featured_artist_exclusion_ids,
 }) => {
   return {
     title,
@@ -54,6 +55,7 @@ export const sanitizeRow = ({
       tag_id,
       keyword,
     },
+    featuredArtistExclusionIds: splitmap(featured_artist_exclusion_ids),
   } as Collection
 }
 


### PR DESCRIPTION
Collaboration with @xtina-starr 
Addresses https://artsyproduct.atlassian.net/browse/GROW-1596

This PR adds a new field to collections named `featuredArtistExclusionIds`. Due to the very broad coverage of the genes we're using to drive our hubs, some hubs are showing unexpected artists under "Featured Artists". With this field, our team can specify artists to exclude from the featured artists section.

We verified locally that with this change, we could add the field to the ingest spreadsheet, ingest it & get it persisted, then read it in a graphQL query.