### PR TITLE
Sanitize string inputs in ingest. 

### DIFF
--- a/src/Routes/__tests__/GSheetImport.test.ts
+++ b/src/Routes/__tests__/GSheetImport.test.ts
@@ -62,7 +62,7 @@ describe("GSheetImport", () => {
           query: {
             artist_ids: ["4d8b92b34eb68a1b2c0003f4"],
             gene_ids: [],
-            tag_id: "",
+            tag_id: null,
             keyword: "Superman",
           },
           linkedCollections: [],
@@ -85,6 +85,8 @@ describe("GSheetImport", () => {
           query: {
             artist_ids: ["4de528068236f6000100070b"],
             gene_ids: ["etching-slash-engraving"],
+            tag_id: null,
+            keyword: null,
           },
           linkedCollections: [],
           featuredArtistExclusionIds: [],
@@ -105,7 +107,7 @@ describe("GSheetImport", () => {
           query: {
             artist_ids: ["4e677d4ff8597e00010072e0"],
             gene_ids: [],
-            tag_id: "",
+            tag_id: null,
             keyword:
               "Yosemite, El Capitan, Half Dome, Sentinel Dome, fern spring, Half Dome, nevada falls, Tuolomne Meadows",
           },

--- a/src/utils/__tests__/convertCSVToJSON.test.ts
+++ b/src/utils/__tests__/convertCSVToJSON.test.ts
@@ -26,8 +26,8 @@ describe("convertCSVToJSON", () => {
         query: {
           artist_ids: ["4dde70a1306f6800010036ef"],
           gene_ids: ["lithograph-1"],
-          tag_id: "",
-          keyword: "",
+          tag_id: null,
+          keyword: null,
         },
         price_guidance: 1000,
         show_on_editorial: true,
@@ -46,7 +46,7 @@ describe("convertCSVToJSON", () => {
         query: {
           artist_ids: ["4d8b92b34eb68a1b2c0003f4"],
           gene_ids: [],
-          tag_id: "",
+          tag_id: null,
           keyword: "Banana",
         },
         show_on_editorial: false,
@@ -94,7 +94,7 @@ describe("convertCSVToJSON", () => {
         query: {
           artist_ids: ["4ddbb20eb773bf00010031ea"],
           gene_ids: ["lithograph-1", "lithograph-2"],
-          tag_id: "",
+          tag_id: null,
           keyword: "lithograph",
         },
       },
@@ -120,7 +120,7 @@ describe("convertCSVToJSON", () => {
         query: {
           artist_ids: ["4ddbb20eb773bf00010031ea"],
           gene_ids: [],
-          tag_id: "",
+          tag_id: null,
           keyword: "praise",
         },
       },
@@ -138,12 +138,15 @@ describe("convertCSVToJSON", () => {
         show_on_editorial: false,
         is_featured_artist_content: false,
         linkedCollections: [
-          { name: "Featured Collections", members: ["agnes-martin-lithographs"] },
+          {
+            name: "Featured Collections",
+            members: ["agnes-martin-lithographs"],
+          },
         ],
         query: {
           artist_ids: ["4e1716d0f1bf8f00010023d8"],
           gene_ids: [],
-          tag_id: "",
+          tag_id: null,
           keyword: "bust",
         },
       },

--- a/src/utils/__tests__/processInput.test.ts
+++ b/src/utils/__tests__/processInput.test.ts
@@ -1,0 +1,16 @@
+import { sanitizeString } from "../processInput"
+
+describe("processInput", () => {
+  describe("sanitizeString", () => {
+    it.each`
+      value           | expected
+      ${"some-value"} | ${"some-value"}
+      ${undefined}    | ${null}
+      ${""}           | ${null}
+    `("returns $expected when value is $value", ({ value, expected }) => {
+      const result = sanitizeString(value)
+
+      expect(result).toEqual(expected)
+    })
+  })
+})

--- a/src/utils/processInput.ts
+++ b/src/utils/processInput.ts
@@ -52,14 +52,16 @@ export const sanitizeRow = ({
     query: {
       artist_ids: splitmap(artist_ids),
       gene_ids: splitmap(gene_ids),
-      tag_id,
-      keyword,
+      tag_id: sanitizeString(tag_id),
+      keyword: sanitizeString(keyword),
     },
     featuredArtistExclusionIds: splitmap(featured_artist_exclusion_ids),
   } as Collection
 }
 
 const splitmap = text => (text ? text.split(",").map(a => a.trim()) : [])
+
+export const sanitizeString = (text: string) => (text ? text : null)
 
 const buildLinkedCollections = (
   { label: artistLabel, collection: artist },


### PR DESCRIPTION
When we [updated the `typeorm` dependency](https://github.com/artsy/kaws/pull/161), it surfaced the fact that we are storing empty `tag_id` and `keyword` fields as empty strings, instead of `null` or not storing them at all. The `typeorm` update stopped returning these empty strings as `null`, and started returning them as empty strings. This caused all artist and collection pages to break, because we started passing an empty `tag_id` query-string param in requests to Gravity. 

Part 1 of the fix was to correct the data that's already stored. I've done this in staging, and will do it in production shortly.

This PR is part 2 - it prevents _new_ data from getting written with empty strings instead of nulls. 