### PR TITLE
fix price-guidance

### DIFF
--- a/src/utils/__tests__/getPriceGuidance.test.ts
+++ b/src/utils/__tests__/getPriceGuidance.test.ts
@@ -1,4 +1,8 @@
-import { getPriceGuidance, getPriceInDollars } from "../getPriceGuidance"
+import {
+  generateQuery,
+  getPriceGuidance,
+  getPriceInDollars,
+} from "../getPriceGuidance"
 
 jest.mock("../../lib/metaphysics", () => ({
   default: jest.fn(),
@@ -10,6 +14,33 @@ describe("#getPriceGuidance", () => {
   afterEach(() => {
     mockMetaphysics.mockClear()
   })
+
+  it("requests the five cheapest items in the given collection that still have a price", () => {
+    expect(generateQuery("foo-bar-baz")).toMatchInlineSnapshot(`
+"{
+  marketingCollection(slug: \\"foo-bar-baz\\") {
+    artworks(aggregations: [TOTAL], price_range: \\"10-*\\", sort: \\"-has_price,prices\\") {
+      artworks_connection(first: 5) {
+        edges {
+          node {
+            artist {
+              name
+            }
+            title
+            price
+            priceCents {
+              min
+              max
+            }
+          }
+        }
+      }
+    }
+  }
+}"
+`)
+  })
+
   it("calculates the average of the 5 lowest artworks of a collection rounded to the nearest 100th", async () => {
     const results = {
       marketingCollection: {

--- a/src/utils/getPriceGuidance.ts
+++ b/src/utils/getPriceGuidance.ts
@@ -11,29 +11,31 @@ export const getPriceInDollars = priceCents => {
   }
 }
 
-export const getPriceGuidance = async (slug: string) => {
-  try {
-    const results: any = await metaphysics(`{
-      marketingCollection(slug: "${slug}") {
-        artworks(aggregations: [TOTAL], price_range: "10-*", sort: "-has_price,-prices") {
-          artworks_connection(first: 5) {
-            edges {
-              node {
-                artist {
-                  name
-                }
-                title
-                price
-                priceCents {
-                  min
-                  max
-                }
-              }
+export const generateQuery = (slug: string) => `{
+  marketingCollection(slug: "${slug}") {
+    artworks(aggregations: [TOTAL], price_range: "10-*", sort: "-has_price,prices") {
+      artworks_connection(first: 5) {
+        edges {
+          node {
+            artist {
+              name
+            }
+            title
+            price
+            priceCents {
+              min
+              max
             }
           }
         }
       }
-    }`)
+    }
+  }
+}`
+
+export const getPriceGuidance = async (slug: string) => {
+  try {
+    const results: any = await metaphysics(generateQuery(slug))
     let avgPrice
     let hasNoBasePrice
 


### PR DESCRIPTION
An October change to the price guidance logic to add a null pointer check also accidentally flipped the sort order of collection items - we were pulling the five most expensive items, not the five least expensive items.

This PR fixes that change. Once it's been merged to staging we should immediately see the following recover to more normal numbers:

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/603525/69277906-28ce1c00-0baf-11ea-8c49-75c98a675e6d.png">
