### PR TITLE
FX-1801: Expose isDepartment in the API

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -60,6 +60,7 @@ type Collection {
   # IDs of artists that should be excluded from Featured Artists for this collection
   featuredArtistExclusionIds: [String!]
   relatedCollections(size: Int = 10): [Collection!]!
+  isDepartment: Boolean!
 }
 
 type CollectionCategory {

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from "lodash"
+import { filter, isEmpty } from "lodash"
 import { Arg, FieldResolver, Int, Query, Resolver, Root } from "type-graphql"
 import { getMongoRepository } from "typeorm"
 import { CollectionGroup } from "../Entities"
@@ -124,6 +124,19 @@ export class CollectionsResolver {
     })
 
     return relatedCategoryResults
+  }
+
+  @FieldResolver(type => Boolean)
+  isDepartment(@Root() collection: Collection) {
+    const linkedCollectionsWithMembers = filter(
+      collection.linkedCollections,
+      linkedCollection => {
+        const membersLength =
+          linkedCollection.members && linkedCollection.members.length
+        return membersLength > 0
+      }
+    )
+    return linkedCollectionsWithMembers.length > 0
   }
 
   @FieldResolver(type => [CollectionGroup])

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -64,7 +64,7 @@ describe("Collections", () => {
     `
 
     return runQuery(query, {}, createMockSchema).then(data => {
-      expect((data as any).collections.length).toBe(8)
+      expect((data as any).collections.length).toBe(9)
       expect(mockedGetMongoRepository).toBeCalled()
       expect(data).toEqual({
         collections: [
@@ -172,6 +172,20 @@ describe("Collections", () => {
               tag_id: null,
             },
             price_guidance: null,
+            show_on_editorial: false,
+            is_featured_artist_content: true,
+          },
+          {
+            id: "9",
+            title: "Andy Warhol: Shoes",
+            description:
+              '<p>In 1954, two years after being discharged from the United States Army, the 24-year-old <a href="https://www.artsy.net/artist/jasper-johns">Jasper Johns</a> had a vivid dream of the American flag.</p>',
+            slug: "andy-warhol-shoes",
+            query: {
+              id: null,
+              tag_id: null,
+            },
+            price_guidance: 1000,
             show_on_editorial: false,
             is_featured_artist_content: true,
           },
@@ -345,6 +359,7 @@ describe("Categories", () => {
               { title: "KAWS: Bearbrick" },
               { title: "KAWS: Bape" },
               { title: "KAWS: Together" },
+              { title: "Andy Warhol: Shoes" },
             ],
           },
         ],
@@ -480,6 +495,88 @@ describe("Collection", () => {
           show_on_editorial: true,
         },
         take: 5,
+      })
+    })
+  })
+
+  describe("isDepartment", () => {
+    it("returns true if the collection has linkedCollections", () => {
+      const query = `
+        {
+          collection(slug: "kaws-companions") {
+            id
+            isDepartment
+          }
+        }
+      `
+
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(data).toEqual({
+          collection: {
+            id: "1",
+            isDepartment: true,
+          },
+        })
+      })
+    })
+
+    it("returns false if the linkedCollections field is not set", () => {
+      const query = `
+        {
+          collection(slug: "collectible-sculptures") {
+            id
+            isDepartment
+          }
+        }
+      `
+
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(data).toEqual({
+          collection: {
+            id: "2",
+            isDepartment: false,
+          },
+        })
+      })
+    })
+
+    it("returns false if there are linkedCollections but they have no members", () => {
+      const query = `
+        {
+          collection(slug: "andy-warhol-shoes") {
+            id
+            isDepartment
+          }
+        }
+      `
+
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(data).toEqual({
+          collection: {
+            id: "9",
+            isDepartment: false,
+          },
+        })
+      })
+    })
+
+    it("returns false if there are no linkedCollections", () => {
+      const query = `
+        {
+          collection(slug: "jasper-johns-flags") {
+            id
+            isDepartment
+          }
+        }
+      `
+
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(data).toEqual({
+          collection: {
+            id: "3",
+            isDepartment: false,
+          },
+        })
       })
     })
   })

--- a/src/Resolvers/__tests__/fixtures/data.ts
+++ b/src/Resolvers/__tests__/fixtures/data.ts
@@ -20,6 +20,7 @@ export const mockCollectionRepository = plainToClass(Collection, [
     show_on_editorial: false,
     price_guidance: null,
     is_featured_artist_content: true,
+    linkedCollections: [{ id: "abc", members: [{ name: "Linked 1" }] }],
   },
   {
     id: 2,
@@ -55,6 +56,7 @@ export const mockCollectionRepository = plainToClass(Collection, [
     show_on_editorial: false,
     price_guidance: 1000,
     is_featured_artist_content: true,
+    linkedCollections: [],
   },
   {
     id: 4,
@@ -145,5 +147,23 @@ export const mockCollectionRepository = plainToClass(Collection, [
     show_on_editorial: false,
     price_guidance: null,
     is_featured_artist_content: true,
+  },
+  {
+    id: 9,
+    _id: 9,
+    title: "Andy Warhol: Shoes",
+    category: "Pop Art",
+    description:
+      '<p>In 1954, two years after being discharged from the United States Army, the 24-year-old <a href="https://www.artsy.net/artist/jasper-johns">Jasper Johns</a> had a vivid dream of the American flag.</p>',
+    slug: "andy-warhol-shoes",
+    headerImage: "http://files.artsy.net/images/jasperjohnsflag.png",
+    query: {
+      id: null,
+      tag_id: null,
+    },
+    show_on_editorial: false,
+    price_guidance: 1000,
+    is_featured_artist_content: true,
+    linkedCollections: [{ id: "bcd", members: [] }],
   },
 ])

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -62,6 +62,7 @@ type Collection {
   # IDs of artists that should be excluded from Featured Artists for this collection
   featuredArtistExclusionIds: [String!]
   relatedCollections(size: Int = 10): [Collection!]!
+  isDepartment: Boolean!
 }
 
 type CollectionCategory {


### PR DESCRIPTION
Paired with @xtina-starr !

![image](https://user-images.githubusercontent.com/2081340/74442563-b4b6b380-4e3f-11ea-942f-33a8326a7110.png)

### Problem
Currently, client apps (currently just reaction, but soon Emission) have to do a little bit of business logic to determine whether or not a collection is a "department" or not. It's not _horribly_ messy, but given we're starting to treat departments as more first-class (i.e. by labeling them differently in search, potentially having a different URL structure), it feels like a good time to push more of this logic to the current source of truth (KAWS).

### Solution
We debated whether to have this be a field in the database or simply resolved at the API level. Given there's no explicit need just yet to have this be in the database (and that would necessitate additional changes, like changing our import script or the spreadsheet), it felt that we could achieve our current desired outcome by adding this field to the API. It should be easy enough to persist this value down the line if we need to.

### One Interesting Thing
Although the [logic in reaction](https://github.com/artsy/reaction/blob/1fd632de985d9a4cb58940091601c896da08031f/src/Apps/Collect2/Routes/Collection/index.tsx#L76) to determine whether a collection is a department or not only checks the length of the `linkedCollections` array, we chose to additionally verify that there is at least one `linkedCollection` _with `members`_.

It sort of suggests that down-the-line we'll want a more first-class understanding (vs. just deriving based on fields) of what a "department" is, but felt like an edge case to avoid for now. Let me know if you'd prefer we use the simpler logic for now!