### PR TITLE
Add package script to pull db from staging or production

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   ],
   "license": "MIT",
   "scripts": {
-    "update-database": "ts-node scripts/bootstrapOrUpdate.ts",
     "build": "tsc",
     "dev": "nodemon --inspect -r ts-node/register src/index.ts",
     "dump-schema": "ts-node scripts/dumpSchema.ts",
@@ -17,12 +16,13 @@
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "release": "release-it",
     "start": "node build/index.js",
+    "test-google-config": "node scripts/test_google_config.js",
     "test": "jest",
     "type-check": "tsc --noEmit",
-    "update-sitemap": "ts-node scripts/updateSitemap.ts",
-    "watch": "tsc --watch",
+    "update-database": "ts-node scripts/bootstrapOrUpdate.ts",
     "update-sailthru": "ts-node scripts/pushCollectionsToSailthru.ts",
-    "test-google-config": "node scripts/test_google_config.js"
+    "update-sitemap": "ts-node scripts/updateSitemap.ts",
+    "watch": "tsc --watch"
   },
   "jest": {
     "preset": "ts-jest",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dump-schema": "ts-node scripts/dumpSchema.ts",
     "index-for-search": "ts-node scripts/indexForSearch.ts",
     "lint": "tslint 'src/**/*.{ts,tsx}'",
+    "pull-database": "./scripts/pull-database.sh",
     "release": "release-it",
     "start": "node build/index.js",
     "test-google-config": "node scripts/test_google_config.js",

--- a/scripts/pull-database.sh
+++ b/scripts/pull-database.sh
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+# get ready to colorize output for clarity
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+GRAY='\033[0;37m'
+RESET='\033[0m'
+
+
+# use environment passed in on command line, or default to staging
+ENVIRONMENT=${1:-staging}
+
+# find mongo connection uri for that environment
+DB_URI=`kubectl --context $ENVIRONMENT get configmap kaws-environment -o jsonpath="{.data.MONGOHQ_URL}"`
+
+# pull remote data
+echo "${BLUE}Dumping $ENVIRONMENT database. If this step fails or times out, make sure you are connected to the $ENVIRONMENT VPN.${GRAY}"
+mongodump --uri=$DB_URI --out=./tmp-mongo-dump
+
+# replace local db
+echo "${BLUE}Replacing local database.${GRAY}"
+mongorestore --drop ./tmp-mongo-dump
+
+# clean up
+if [ $? -eq 0 ]
+then
+  echo "${BLUE}Cleaning up.${GRAY}"
+  rm -rf ./tmp-mongo-dump
+  echo "${BLUE}Done.${RESET}"
+else
+  echo "${RED}mongorestore exited with non-zero status.${RESET}"
+fi


### PR DESCRIPTION
## Problem

Nowadays it has become expensive to run `yarn update-database` in order to bootstrap a local copy of realistic data (thanks to the price calculations that hit MP for most of the 2000+ collections)

## Solution

This PR adds a `yarn pull-database` script that will simply replace your local kaws database with the contents of the staging database. (You can also `yarn pull-database production` in order to pull down production data.)

![pulldb](https://user-images.githubusercontent.com/140521/74566868-7950dd80-4f42-11ea-9e54-0c3e7f51c4b9.png)
