### PR TITLE
Add cron jobs to sync data from production to staging envs

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,2 +1,2 @@
 project-name: kaws
-hokusai-required-version: ">=0.5.3"
+hokusai-required-version: "~=0.5"

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -152,6 +152,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 2
       template:
         spec:
           containers:
@@ -176,7 +177,7 @@ spec:
                         operator: In
                         values:
                           - background
-      backoffLimit: 2
+
 ---
 apiVersion: batch/v2alpha1
 kind: CronJob
@@ -187,6 +188,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 2
       template:
         spec:
           containers:
@@ -211,7 +213,7 @@ spec:
                         operator: In
                         values:
                           - background
-      backoffLimit: 2
+
 ---
 apiVersion: batch/v2alpha1
 kind: CronJob
@@ -222,6 +224,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 2
       template:
         spec:
           containers:
@@ -246,4 +249,39 @@ spec:
                         operator: In
                         values:
                           - background
-      backoffLimit: 2
+
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: kaws-data-export
+spec:
+  schedule: "0 5 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: kaws-data-export-cron
+              image: artsy/mongo-data-sync
+              imagePullPolicy: Always
+              env:
+                - name: APP_NAME
+                  value: "kaws"
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+              args: ["sh", "./export-db.sh", "production"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -152,6 +152,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 2
       template:
         spec:
           containers:
@@ -176,7 +177,7 @@ spec:
                         operator: In
                         values:
                           - background
-      backoffLimit: 2
+
 ---
 apiVersion: batch/v2alpha1
 kind: CronJob
@@ -187,6 +188,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 2
       template:
         spec:
           containers:
@@ -211,4 +213,39 @@ spec:
                         operator: In
                         values:
                           - background
-      backoffLimit: 2
+
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: kaws-data-import
+spec:
+  schedule: "0 6 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: kaws-data-import-cron
+              image: artsy/mongo-data-sync
+              imagePullPolicy: Always
+              env:
+                - name: APP_NAME
+                  value: "kaws"
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+              args: ["sh", "./import-db.sh", "production"]
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background


### PR DESCRIPTION
Changes In this PR

- Small update to pinned version of hokusai

- Add cron jobs to sync data from production to staging envs
Export job will run at `5` UTC, and the import job on staging will run at `6` UTC