### PR TITLE
Allows for filtering collections by a list of slugs

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -141,6 +141,7 @@ enum GroupTypes {
 
 type Query {
   collections(
+    slugs: [String!]
     category: String
     randomizationSeed: String
     size: Int

--- a/src/Resolvers/Collections.ts
+++ b/src/Resolvers/Collections.ts
@@ -17,7 +17,8 @@ export class CollectionsResolver {
     isFeaturedArtistContent: boolean,
     @Arg("size", () => Int, { nullable: true }) size: number,
     @Arg("randomizationSeed", { nullable: true }) randomizationSeed: string,
-    @Arg("category", { nullable: true }) category: string
+    @Arg("category", { nullable: true }) category: string,
+    @Arg("slugs", type => [String], { nullable: true }) slugs: string[]
   ): Promise<Collection[]> {
     const hasArguments =
       [].filter.call(arguments, arg => arg !== undefined).length > 0
@@ -26,18 +27,25 @@ export class CollectionsResolver {
     if (isFeaturedArtistContent !== undefined) {
       query.where.is_featured_artist_content = isFeaturedArtistContent
     }
+
     if (showOnEditorial !== undefined) {
       query.where.show_on_editorial = showOnEditorial
     }
+
     if (artistID) {
       query.where["query.artist_ids"] = { $in: [artistID] }
     }
+
     if (!randomizationSeed && size) {
       query.take = size
     }
 
     if (category !== undefined) {
       query.where.category = { $in: [category] }
+    }
+
+    if (slugs !== undefined && slugs.length > 0) {
+      query.where.slug = { $in: slugs }
     }
 
     if (randomizationSeed) {

--- a/src/Resolvers/__tests__/collection_resolvers.test.ts
+++ b/src/Resolvers/__tests__/collection_resolvers.test.ts
@@ -331,6 +331,73 @@ describe("Collections", () => {
       })
     })
   })
+
+  describe("slugs", () => {
+    it("can filter by an array of slugs", () => {
+      const query = `
+        {
+          collections(slugs: ["andy-warhol-shoes", "jasper-johns-flags", "kaws-companions"]) {
+            slug
+          }
+        }
+      `
+
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(find).toBeCalledWith({
+          where: {
+            slug: {
+              $in: [
+                "andy-warhol-shoes",
+                "jasper-johns-flags",
+                "kaws-companions",
+              ],
+            },
+          },
+        })
+      })
+    })
+
+    it("handles an empty array input", () => {
+      const query = `
+        {
+          collections(slugs: []) {
+            slug
+          }
+        }
+      `
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(find).toBeCalledWith({
+          where: {},
+        })
+      })
+    })
+
+    it("can filter by slugs and another param", () => {
+      const query = `
+        {
+          collections(slugs: ["andy-warhol-shoes", "jasper-johns-flags", "kaws-companions"], category: "Pop Art") {
+            slug
+          }
+        }
+      `
+      return runQuery(query, {}, createMockSchema).then(data => {
+        expect(find).toBeCalledWith({
+          where: {
+            slug: {
+              $in: [
+                "andy-warhol-shoes",
+                "jasper-johns-flags",
+                "kaws-companions",
+              ],
+            },
+            category: {
+              $in: ["Pop Art"],
+            },
+          },
+        })
+      })
+    })
+  })
 })
 
 describe("Categories", () => {

--- a/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/createSchema.test.ts.snap
@@ -139,7 +139,7 @@ enum GroupTypes {
 }
 
 type Query {
-  collections(category: String, randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean, artistID: String): [Collection!]!
+  collections(slugs: [String!], category: String, randomizationSeed: String, size: Int, isFeaturedArtistContent: Boolean, showOnEditorial: Boolean, artistID: String): [Collection!]!
   categories: [CollectionCategory!]!
   collection(slug: String!): Collection
   hubCollections: [Collection!]!


### PR DESCRIPTION
As part of the "Art Keeps Going" campaign, we need to be able to pull a list of collections filtered by an arbitrary list of slugs (curated by an admin).

This seems like helpful functionality in any case!

Example of just querying by slugs:
![image](https://user-images.githubusercontent.com/2081340/78500987-b8700380-7727-11ea-9ea6-dc09c6c0b72a.png)

Example of querying by slugs and another param (in this case `category`):
![image](https://user-images.githubusercontent.com/2081340/78500995-ca51a680-7727-11ea-9f01-430793988948.png)
