### PR TITLE
@anandaroop => [Cron] Schedule a daily task to update price guidance field for each collection

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -250,6 +250,41 @@ spec:
                         values:
                           - background
 
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: kaws-update-price-guidance
+spec:
+  schedule: 0 13 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          containers:
+            - name: kaws-update-price-guidance
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/kaws:production
+              args:
+                - "yarn"
+                - "run"
+                - "update-price-guidance"
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background
 
 ---
 apiVersion: batch/v1beta1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -214,6 +214,41 @@ spec:
                         values:
                           - background
 
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: kaws-update-price-guidance
+spec:
+  schedule: 0 13 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          containers:
+            - name: kaws-update-price-guidance
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/kaws:production
+              args:
+                - "yarn"
+                - "run"
+                - "update-price-guidance"
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: kaws-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background
 
 ---
 apiVersion: batch/v1beta1

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "jest",
     "type-check": "tsc --noEmit",
     "update-database": "ts-node scripts/bootstrapOrUpdate.ts",
+    "update-price-guidance": "ts-node scripts/updatePriceGuidance.ts",
     "update-sailthru": "ts-node scripts/pushCollectionsToSailthru.ts",
     "update-sitemap": "ts-node scripts/updateSitemap.ts",
     "watch": "tsc --watch"

--- a/scripts/updatePriceGuidance.ts
+++ b/scripts/updatePriceGuidance.ts
@@ -1,0 +1,7 @@
+import "dotenv/config"
+import { updatePriceGuidance } from "../src/utils/updatePriceGuidance"
+
+updatePriceGuidance().catch(error => {
+  console.log(error)
+  process.exit(1)
+})

--- a/src/utils/updatePriceGuidance.ts
+++ b/src/utils/updatePriceGuidance.ts
@@ -1,0 +1,79 @@
+import "dotenv/config"
+import { Connection, createConnection, getMongoRepository } from "typeorm"
+import { MongoClient } from "mongodb"
+import { databaseURL } from "../config/database"
+import { databaseConfig } from "../config/database"
+import { Collection } from "../Entities"
+import { getPriceGuidance } from "./getPriceGuidance"
+
+/**
+ * This updates the price guidance field for all valid collections.
+ */
+
+interface ErrorRecord {
+  slug: string
+  reason: string
+  data: string
+}
+
+export const updatePriceGuidance = async () => {
+  let connection: Connection | undefined
+  const erroredCollections: ErrorRecord[] = []
+  try {
+    const connectionArgs = databaseConfig()
+    connection = await createConnection(connectionArgs)
+    const mongoConnection = await MongoClient.connect(databaseURL!)
+    const database = mongoConnection.db()
+    const mongoCollection = database.collection("collection")
+
+    if (connection.isConnected) {
+      const repository = getMongoRepository(Collection)
+      const collections = await repository.find()
+      for (const collection of collections) {
+        console.log(`[PriceGuidance] Updating ${collection.slug}...`)
+
+        if (!collection.query) {
+          erroredCollections.push({
+            slug: collection.slug,
+            reason: "no query found",
+            data: "",
+          })
+          continue
+        }
+
+        const slug = collection.slug
+        const id = collection.id
+        try {
+          const priceGuidance = await getPriceGuidance(slug)
+          if (priceGuidance) {
+            await mongoCollection.update(
+              { id },
+              { $set: { price_guidance: priceGuidance } }
+            )
+          }
+        } catch (error) {
+          erroredCollections.push({
+            slug: collection.slug,
+            reason: "error fetching artworks",
+            data: error.message,
+          })
+          continue
+        }
+      }
+    } else {
+      throw new Error("could not connect to database")
+    }
+  } finally {
+    /* tslint:disable:no-unused-expression */
+    connection && connection.close()
+    /* tslint:enable:no-unused-expression */
+    if (erroredCollections.length > 0) {
+      console.log(
+        "[PriceGuidance] The following collections encountered an error:"
+      )
+      erroredCollections.map(({ slug, reason }) =>
+        console.log(`${slug} - ${reason}`)
+      )
+    }
+  }
+}


### PR DESCRIPTION
Fairly straightforward. I'm running this locally against staging, and besides a handful of error'ing collections (`young-british-artists` references an artist which no longer exists, etc. - all those collection pages 500 right now anyway), seems to work!

I was also interested to see that the price guidance is the average of the 5 lowest priced works! That's in https://github.com/artsy/kaws/blob/f31692d6d173b3d42bc247d114dafd716d461166/src/utils/getPriceGuidance.ts#L54