### PR TITLE
Tune resource consumption. Add NODE_OPTIONS env var.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -26,6 +26,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
           envFrom:
             - configMapRef:
                 name: kaws-environment
@@ -36,10 +38,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 500m
-              memory: 768Mi
+              cpu: 200m
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi 
           readinessProbe:
             httpGet:
               port: kaws-http

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -26,6 +26,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
           envFrom:
             - configMapRef:
                 name: kaws-environment
@@ -36,10 +38,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 500m
-              memory: 768Mi
+              cpu: 100m
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               port: kaws-http


### PR DESCRIPTION
- Tune resource consumption.
- Add NODE_OPTIONS to specify old heap space to match mem request.

---
https://artsyproduct.atlassian.net/browse/PLATFORM-2652
https://www.notion.so/artsy/Guidelines-on-tuning-an-app-s-CPU-and-memory-consumption-in-a-Kubernetes-cluster-797977be895643af84015a7d4b60a5dc
https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-cpumemory-usage-by-deployment

---
 #trivial
^ to satisfy Peril.