### PR TITLE
Fix production ingress definition

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -176,7 +176,7 @@ metadata:
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
 spec:
   rules:
-    - host: kaws-staging.artsy.net
+    - host: kaws.artsy.net
       http:
         paths:
           - path: /


### PR DESCRIPTION
Follow-up to https://github.com/artsy/kaws/pull/250.

This caused an issue in production, as you'd expect.