### PR TITLE
feat: add a CLI for collection deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "delete-collections": "ts-node scripts/deleteCollections.ts",
     "dev": "nodemon --inspect -r ts-node/register src/index.ts",
     "dump-schema": "ts-node scripts/dumpSchema.ts",
     "index-for-search": "ts-node scripts/indexForSearch.ts",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "jest": "23.6.0",
     "lint-staged": "7.3.0",
     "nodemon": "1.18.10",
-    "prettier": "1.14.3",
+    "prettier": "2.1.2",
     "release-it": "7.6.1",
     "ts-jest": "23.10.5",
     "ts-node": "7.0.1",

--- a/scripts/deleteCollections.ts
+++ b/scripts/deleteCollections.ts
@@ -1,0 +1,14 @@
+import { CollectionRemover } from "../src/lib/utils/collectionRemover"
+
+const slugs = process.argv.slice(2)
+console.log(
+  `Attempting to remove ${slugs.length} collection(s) from Elasticsearch and MongoDB`
+)
+
+const collectionRemover = new CollectionRemover(slugs)
+
+collectionRemover.setup().then(() => {
+  collectionRemover.perform().finally(() => {
+    collectionRemover.teardown()
+  })
+})

--- a/src/lib/utils/collectionRemover.ts
+++ b/src/lib/utils/collectionRemover.ts
@@ -1,0 +1,101 @@
+import {
+  Connection,
+  createConnection,
+  getMongoRepository,
+  MongoRepository,
+} from "typeorm"
+import { Client as ElasticsearchClient } from "elasticsearch"
+import { red, yellow, green } from "bash-color"
+
+import { databaseConfig } from "../../config/database"
+import { Collection } from "../../Entities/Collection"
+
+export class CollectionRemover {
+  private slugs: string[]
+  private mongoConnection: Connection
+  private mongoRepository: MongoRepository<Collection>
+  private elasticsearchClient: ElasticsearchClient
+  private elasticsearchIndexName: string =
+    "marketing_collections_" + process.env.NODE_ENV
+
+  constructor(collectionSlugs: string[]) {
+    this.slugs = collectionSlugs
+    this.checkEnvironment()
+  }
+
+  checkEnvironment = () => {
+    const { MONGOHQ_URL, ELASTICSEARCH_URL } = process.env
+    if (!MONGOHQ_URL) throw new Error("MONGOHQ_URL must be defined")
+    if (!ELASTICSEARCH_URL) throw new Error("ELASTICSEARCH_URL must be defined")
+  }
+
+  setup = async () => {
+    // setup Mongo
+    this.mongoConnection = await createConnection(databaseConfig())
+    if (this.mongoConnection.isConnected) {
+      this.mongoRepository = getMongoRepository(Collection)
+    }
+    // setup Elasticsearch
+    this.elasticsearchClient = new ElasticsearchClient({
+      host: process.env.ELASTICSEARCH_URL,
+      maxRetries: 2,
+      keepAlive: true,
+      maxSockets: 10,
+    })
+  }
+
+  perform = async () => {
+    await Promise.all(this.slugs.map((slug) => this.removeCollection(slug)))
+  }
+
+  removeCollection = async (slug: string) => {
+    try {
+      const collection = await this.mongoRepository.findOne({ slug })
+      if (collection) {
+        await this.removeFromSearchIndex(collection!)
+        await this.removeFromDatabase(collection!)
+        console.log(green(`Removed ${collection?.title}`))
+      } else {
+        console.log(red(`Could not find collection for ${slug}`))
+      }
+    } catch (e) {
+      console.log(red(e.message))
+      throw e
+    }
+  }
+
+  removeFromSearchIndex = async (collection: Collection) => {
+    try {
+      await this.elasticsearchClient.delete({
+        index: this.elasticsearchIndexName,
+        type: "marketing_collection",
+        id: collection.id.toString(),
+      })
+    } catch (e) {
+      if (e.message === "Not Found") {
+        console.log(yellow(`  ${collection.slug} Not found in search index`))
+      } else {
+        console.log(red(e.message))
+        throw e
+      }
+    }
+  }
+
+  removeFromDatabase = async (collection: Collection) => {
+    try {
+      await this.mongoRepository.delete({ slug: collection.slug })
+    } catch (e) {
+      console.log(red(e.message))
+      throw e
+    }
+  }
+
+  teardown = () => {
+    // teardown Mongo
+    if (this.mongoConnection?.isConnected) {
+      this.mongoConnection.close()
+    }
+    // teardown Elasticsearch
+    this.elasticsearchClient.close()
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6188,7 +6188,12 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.14.3, prettier@^1.13.7:
+prettier@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+
+prettier@^1.13.7:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
   integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==


### PR DESCRIPTION
Addresses [FX-2290]

### Problem

Kaws doesn't support deletion of collections, thus requiring developers to monkey around in a Mongo console. Even then, deleted collections remain indexed for search.

### Solution

Add an interface for developers to conveniently and correctly remove collections from Kaws.

My first thought was to add e.g.  a `deleteCollection` mutation to Kaws' GraphQL API. But then I realized we don't enforce any auth on the GraphQL endpoint, so that rules out doing destructive operations there.

Second thought was a CLI — so now this can be accomplished with simply a yarn script and some collection slugs:

```sh
$ yarn delete-collections alex-katz-portraits alex-katz-landscapes
```

Here's what a sample run of this CLI looks like:

![Screen Shot 2020-09-24 at 4 45 02 PM](https://user-images.githubusercontent.com/140521/94198486-577aea00-fe85-11ea-881b-d48f435844a2.png)


[FX-2290]: https://artsyproduct.atlassian.net/browse/FX-2290