### PR TITLE
fix: replace docker-compose extends keyword with Jinja2 template

### DIFF
--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -2,5 +2,4 @@
 version: '2'
 services:
   kaws:
-    build:
-      context: ../
+{% include 'templates/docker-compose-service.yml.j2' %}

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,9 +1,7 @@
 version: "2"
 services:
   kaws:
-    extends:
-      file: build.yml
-      service: kaws
+{% include 'templates/docker-compose-service.yml.j2' %}
     ports:
       - 4000:4000
     env_file: ../.env

--- a/hokusai/templates/docker-compose-service.yml.j2
+++ b/hokusai/templates/docker-compose-service.yml.j2
@@ -1,0 +1,2 @@
+    build:
+      context: ../

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -2,9 +2,7 @@ version: "2"
 services:
   kaws:
     command: ["yarn", "test"]
-    extends:
-      file: build.yml
-      service: kaws
+{% include 'templates/docker-compose-service.yml.j2' %}
     environment:
       - ELASTICSEARCH_URL=http://kaws-elasticsearch:9200
       - MONGOHQ_URL=mongodb://kaws-mongodb:27017/kaws-test


### PR DESCRIPTION
Required for Docker Compose v3 / Hokusai >= v0.5.12 compatibility