### PR TITLE
Remove public ingress declaration

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -110,23 +110,6 @@ kind: Ingress
 metadata:
   name: kaws
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
-spec:
-  rules:
-    - host: kaws.artsy.net
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: kaws-web-internal
-              servicePort: http
-
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: kaws-internal
-  annotations:
     kubernetes.io/ingress.class: nginx-internal
 spec:
   rules:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -110,23 +110,6 @@ kind: Ingress
 metadata:
   name: kaws
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
-spec:
-  rules:
-    - host: kaws-staging.artsy.net
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: kaws-web-internal
-              servicePort: http
-
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: kaws-internal
-  annotations:
     kubernetes.io/ingress.class: nginx-internal
 spec:
   rules:


### PR DESCRIPTION
This is the follow-up to https://github.com/artsy/kaws/pull/272. DNS for the public URLs has already been deleted, and logs confirm no traffic through the external ingress.

Question: Just to stick with our naming convention, I've renamed the internal ingress to `kaws` and deleted the external one with the same name. When these changes are applied, I assume the former `kaws-internal` definition will remain and require manual deletion. Is it a problem that 2 ingress definitions will temporarily list the same host? Any reason to worry that this update won't be graceful?