### PR TITLE
Re-add APP_NAME config for mongo-data-sync operations

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -281,6 +281,9 @@ spec:
             - name: kaws-data-export-cron
               image: artsy/mongo-data-sync
               imagePullPolicy: Always
+              env:
+                - name: APP_NAME
+                  value: "kaws"
               envFrom:
                 - configMapRef:
                     name: kaws-environment

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -245,6 +245,9 @@ spec:
             - name: kaws-data-import-cron
               image: artsy/mongo-data-sync
               imagePullPolicy: Always
+              env:
+                - name: APP_NAME
+                  value: "kaws"
               envFrom:
                 - configMapRef:
                     name: kaws-environment


### PR DESCRIPTION
I noticed [this error](https://github.com/artsy/docker-images/blob/0f94d525264e4a7f8703e7fe7b0565f845d70041/mongo-data-sync/import-db.sh#L23) in staging's daily attempt to copy down production's data. It turns out the `APP_NAME` env var _is_ required, but not by this repo, by the `mongo-data-sync` docker image.

Fixes a bug introduced in https://github.com/artsy/kaws/pull/272.
