### PR TITLE
feat: support indexing to Algolia 

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@sentry/node": "4.6.4",
+    "algoliasearch": "^4.10.5",
     "aws-sdk": "2.377.0",
     "body-parser": "1.18.3",
     "class-transformer": "0.1.9",

--- a/scripts/deleteCollections.ts
+++ b/scripts/deleteCollections.ts
@@ -2,7 +2,7 @@ import { CollectionRemover } from "../src/lib/utils/collectionRemover"
 
 const slugs = process.argv.slice(2)
 console.log(
-  `Attempting to remove ${slugs.length} collection(s) from Elasticsearch and MongoDB`
+  `Attempting to remove ${slugs.length} collection(s) from Elasticsearch, Algolia and MongoDB`
 )
 
 const collectionRemover = new CollectionRemover(slugs)

--- a/src/lib/search/algoliasearch.ts
+++ b/src/lib/search/algoliasearch.ts
@@ -1,0 +1,32 @@
+import algoliasearch from "algoliasearch"
+
+const { NODE_ENV, ALGOLIA_APP_ID, ALGOLIA_API_KEY } = process.env
+
+if (!ALGOLIA_APP_ID || !ALGOLIA_API_KEY) {
+  throw new Error("ALGOLIA_APP_ID or ALGOLIA_API_KEY not defined, skipping...")
+}
+
+// in the Algolia project `KawsCollection` will be the name of the legacy index,
+// and `MarketingCollection` will be the name of the new index from Gravity
+const algoliaIndexName = process.env.ALGOLIA_INDEX_NAME || "KawsCollection"
+
+const algoliaClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+const algoliaIndex = algoliaClient.initIndex(
+  [algoliaIndexName, NODE_ENV].join("_")
+)
+
+export const algoliaSearch = {
+  index: algoliaIndex,
+  client: algoliaClient,
+}
+
+export const algoliaSetSettings = async () => {
+  await algoliaIndex.setSettings({
+    searchableAttributes: [
+      "unordered(name)",
+      "unordered(keyword)",
+      "unordered(category)",
+    ],
+    customRanking: ["desc(search_boost)"],
+  })
+}

--- a/src/lib/search/elasticsearch.ts
+++ b/src/lib/search/elasticsearch.ts
@@ -1,5 +1,6 @@
-const { NODE_ENV, ELASTICSEARCH_URL } = process.env
 const elasticsearch = require("elasticsearch")
+
+const { NODE_ENV, ELASTICSEARCH_URL } = process.env
 
 if (!ELASTICSEARCH_URL) {
   throw new Error("ELASTICSEARCH_URL not defined, skipping...")
@@ -12,6 +13,8 @@ const client = new elasticsearch.Client({
   maxSockets: 10,
 })
 
+// in the Elasticsearch cluster `kaws_collection` will be the name of the legacy
+// index, and `marketing_collection` will be the name of the new index from Gravity
 const indexName =
   process.env.ELASTICSEARCH_INDEX_NAME || "marketing_collections"
 

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,0 +1,1 @@
+export * from "./elasticsearch"

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,1 +1,2 @@
 export * from "./elasticsearch"
+export * from "./algoliasearch"

--- a/src/lib/utils/collectionRemover.ts
+++ b/src/lib/utils/collectionRemover.ts
@@ -9,6 +9,8 @@ import { red, yellow, green } from "bash-color"
 
 import { databaseConfig } from "../../config/database"
 import { Collection } from "../../Entities/Collection"
+import { algoliaSearch } from "../../lib/search"
+import { SearchIndex } from "algoliasearch"
 
 export class CollectionRemover {
   private slugs: string[]
@@ -19,6 +21,7 @@ export class CollectionRemover {
     process.env.ELASTICSEARCH_INDEX_NAME || "marketing_collections",
     process.env.NODE_ENV,
   ].join("_")
+  private algoliaIndex: SearchIndex
 
   constructor(collectionSlugs: string[]) {
     this.slugs = collectionSlugs
@@ -44,6 +47,8 @@ export class CollectionRemover {
       keepAlive: true,
       maxSockets: 10,
     })
+    // setup Algolia
+    this.algoliaIndex = algoliaSearch.index
   }
 
   perform = async () => {
@@ -80,6 +85,12 @@ export class CollectionRemover {
         console.log(red(e.message))
         throw e
       }
+    }
+    try {
+      await this.algoliaIndex.deleteObject(collection.id.toString())
+    } catch (e) {
+      console.log(red(e.message))
+      throw e
     }
   }
 

--- a/src/lib/utils/collectionRemover.ts
+++ b/src/lib/utils/collectionRemover.ts
@@ -15,8 +15,10 @@ export class CollectionRemover {
   private mongoConnection: Connection
   private mongoRepository: MongoRepository<Collection>
   private elasticsearchClient: ElasticsearchClient
-  private elasticsearchIndexName: string =
-    "marketing_collections_" + process.env.NODE_ENV
+  private elasticsearchIndexName: string = [
+    process.env.ELASTICSEARCH_INDEX_NAME || "marketing_collections",
+    process.env.NODE_ENV,
+  ].join("_")
 
   constructor(collectionSlugs: string[]) {
     this.slugs = collectionSlugs

--- a/src/utils/__tests__/indexForSearch.test.ts
+++ b/src/utils/__tests__/indexForSearch.test.ts
@@ -5,6 +5,11 @@ jest.mock("../../lib/search", () => ({
     client: { index: jest.fn() },
     index: "marketing_collections_development",
   },
+  algoliaSearch: {
+    client: { initIndex: jest.fn() },
+    index: { saveObject: jest.fn() },
+  },
+  algoliaSetSettings: jest.fn(),
 }))
 jest.mock("typeorm", () => {
   return {
@@ -19,7 +24,11 @@ jest.mock("../../lib/metaphysics", () => ({
 
 import { createConnection, getMongoRepository } from "typeorm"
 import { metaphysics as MetaphysicsMock } from "../../lib/metaphysics"
-import { search as SearchMock } from "../../lib/search"
+import {
+  search as SearchMock,
+  algoliaSearch,
+  algoliaSetSettings,
+} from "../../lib/search"
 import { indexForSearch } from "../indexForSearch"
 
 const createConnectionMock = createConnection as jest.Mock<any>
@@ -102,5 +111,8 @@ describe("indexForSearch", () => {
     expect(secondCollection.body.visible_to_public).toBe(true)
     expect(secondCollection.body.search_boost).toBe(1000)
     expect(firstCollection.body.image_url).toBe("/path/to/happy/cats.jpg")
+
+    expect(algoliaSetSettings).toHaveBeenCalledTimes(1)
+    expect(algoliaSearch.index.saveObject).toHaveBeenCalledTimes(2)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,110 @@
 # yarn lockfile v1
 
 
+"@algolia/cache-browser-local-storage@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.5.tgz#961cf07cf59955de17af13bd74f7806bd2119553"
+  integrity sha512-cfX2rEKOtuuljcGI5DMDHClwZHdDqd2nT2Ohsc8aHtBiz6bUxKVyIqxr2gaC6tU8AgPtrTVBzcxCA+UavXpKww==
+  dependencies:
+    "@algolia/cache-common" "4.10.5"
+
+"@algolia/cache-common@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-common/-/cache-common-4.10.5.tgz#9510419e9dfb6d8814582c6b20615196f213a9d6"
+  integrity sha512-1mClwdmTHll+OnHkG+yeRoFM17kSxDs4qXkjf6rNZhoZGXDvfYLy3YcZ1FX4Kyz0DJv8aroq5RYGBDsWkHj6Tw==
+
+"@algolia/cache-in-memory@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/cache-in-memory/-/cache-in-memory-4.10.5.tgz#de9331cb86734bf7f7624063cdaa639e43509be1"
+  integrity sha512-+ciQnfIGi5wjMk02XhEY8fmy2pzy+oY1nIIfu8LBOglaSipCRAtjk6WhHc7/KIbXPiYzIwuDbM2K1+YOwSGjwA==
+  dependencies:
+    "@algolia/cache-common" "4.10.5"
+
+"@algolia/client-account@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/client-account/-/client-account-4.10.5.tgz#82f7c330fc5f0625b5b559afe9c6b1aa6722b6cf"
+  integrity sha512-I9UkSS2glXm7RBZYZIALjBMmXSQbw/fI/djPcBHxiwXIheNIlqIFl2SNPkvihpPF979BSkzjqdJNRPhE1vku3Q==
+  dependencies:
+    "@algolia/client-common" "4.10.5"
+    "@algolia/client-search" "4.10.5"
+    "@algolia/transporter" "4.10.5"
+
+"@algolia/client-analytics@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/client-analytics/-/client-analytics-4.10.5.tgz#269e47c9de7e53e9e05e4a2d3c380607c3d2631f"
+  integrity sha512-h2owwJSkovPxzc+xIsjY1pMl0gj+jdVwP9rcnGjlaTY2fqHbSLrR9yvGyyr6305LvTppxsQnfAbRdE/5Z3eFxw==
+  dependencies:
+    "@algolia/client-common" "4.10.5"
+    "@algolia/client-search" "4.10.5"
+    "@algolia/requester-common" "4.10.5"
+    "@algolia/transporter" "4.10.5"
+
+"@algolia/client-common@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/client-common/-/client-common-4.10.5.tgz#a7d0833796a9a2da68be16be76b6dc3962bf2f18"
+  integrity sha512-21FAvIai5qm8DVmZHm2Gp4LssQ/a0nWwMchAx+1hIRj1TX7OcdW6oZDPyZ8asQdvTtK7rStQrRnD8a95SCUnzA==
+  dependencies:
+    "@algolia/requester-common" "4.10.5"
+    "@algolia/transporter" "4.10.5"
+
+"@algolia/client-personalization@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/client-personalization/-/client-personalization-4.10.5.tgz#78a8fb8161bdbeaa66b400b3283640ef689e155b"
+  integrity sha512-nH+IyFKBi8tCyzGOanJTbXC5t4dspSovX3+ABfmwKWUYllYzmiQNFUadpb3qo+MLA3jFx5IwBesjneN6dD5o3w==
+  dependencies:
+    "@algolia/client-common" "4.10.5"
+    "@algolia/requester-common" "4.10.5"
+    "@algolia/transporter" "4.10.5"
+
+"@algolia/client-search@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/client-search/-/client-search-4.10.5.tgz#47907232a3e4ecf2aa4459b8de17242afd88147c"
+  integrity sha512-1eQFMz9uodrc5OM+9HeT+hHcfR1E1AsgFWXwyJ9Q3xejA2c1c4eObGgOgC9ZoshuHHdptaTN1m3rexqAxXRDBg==
+  dependencies:
+    "@algolia/client-common" "4.10.5"
+    "@algolia/requester-common" "4.10.5"
+    "@algolia/transporter" "4.10.5"
+
+"@algolia/logger-common@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-common/-/logger-common-4.10.5.tgz#cf807107e755ad4a72c5afc787e968ff1196f1cc"
+  integrity sha512-gRJo9zt1UYP4k3woEmZm4iuEBIQd/FrArIsjzsL/b+ihNoOqIxZKTSuGFU4UUZOEhvmxDReiA4gzvQXG+TMTmA==
+
+"@algolia/logger-console@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/logger-console/-/logger-console-4.10.5.tgz#f961a7a7c6718c3f3842fb9b522d47b03b9df8ad"
+  integrity sha512-4WfIbn4253EDU12u9UiYvz+QTvAXDv39mKNg9xSoMCjKE5szcQxfcSczw2byc6pYhahOJ9PmxPBfs1doqsdTKQ==
+  dependencies:
+    "@algolia/logger-common" "4.10.5"
+
+"@algolia/requester-browser-xhr@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.5.tgz#7063e3bc6d9c72bc535e1794352eddf47459dfe6"
+  integrity sha512-53/MURQEqtK+bGdfq4ITSPwTh5hnADU99qzvpAINGQveUFNSFGERipJxHjTJjIrjFz3vxj5kKwjtxDnU6ygO9g==
+  dependencies:
+    "@algolia/requester-common" "4.10.5"
+
+"@algolia/requester-common@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-common/-/requester-common-4.10.5.tgz#52abfbf10b743d26afd3ce20f62771bc393ff4f0"
+  integrity sha512-UkVa1Oyuj6NPiAEt5ZvrbVopEv1m/mKqjs40KLB+dvfZnNcj+9Fry4Oxnt15HMy/HLORXsx4UwcthAvBuOXE9Q==
+
+"@algolia/requester-node-http@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/requester-node-http/-/requester-node-http-4.10.5.tgz#db7e9ece1fda1b71a28c8e623666aaa096320b5c"
+  integrity sha512-aNEKVKXL4fiiC+bS7yJwAHdxln81ieBwY3tsMCtM4zF9f5KwCzY2OtN4WKEZa5AAADVcghSAUdyjs4AcGUlO5w==
+  dependencies:
+    "@algolia/requester-common" "4.10.5"
+
+"@algolia/transporter@4.10.5":
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/@algolia/transporter/-/transporter-4.10.5.tgz#9354989f12af3e2ce7d3109a94f519d467a960e0"
+  integrity sha512-F8DLkmIlvCoMwSCZA3FKHtmdjH3o5clbt0pi2ktFStVNpC6ZDmY307HcK619bKP5xW6h8sVJhcvrLB775D2cyA==
+  dependencies:
+    "@algolia/cache-common" "4.10.5"
+    "@algolia/logger-common" "4.10.5"
+    "@algolia/requester-common" "4.10.5"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.0.0-beta.35":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -381,6 +485,26 @@ ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+algoliasearch@^4.10.5:
+  version "4.10.5"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.10.5.tgz#1faf34a3ae5ac3bef27282eb141251c70c7f5db2"
+  integrity sha512-KmH2XkiN+8FxhND4nWFbQDkIoU6g2OjfeU9kIv4Lb+EiOOs3Gpp7jvd+JnatsCisAZsnWQdjd7zVlW7I/85QvQ==
+  dependencies:
+    "@algolia/cache-browser-local-storage" "4.10.5"
+    "@algolia/cache-common" "4.10.5"
+    "@algolia/cache-in-memory" "4.10.5"
+    "@algolia/client-account" "4.10.5"
+    "@algolia/client-analytics" "4.10.5"
+    "@algolia/client-common" "4.10.5"
+    "@algolia/client-personalization" "4.10.5"
+    "@algolia/client-search" "4.10.5"
+    "@algolia/logger-common" "4.10.5"
+    "@algolia/logger-console" "4.10.5"
+    "@algolia/requester-browser-xhr" "4.10.5"
+    "@algolia/requester-common" "4.10.5"
+    "@algolia/requester-node-http" "4.10.5"
+    "@algolia/transporter" "4.10.5"
 
 ansi-align@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/FX-3296

This adds Algolia support to the existing `indexForSearch` script

It does so by:

- lightly refactoring the Elasticsearch code, so that it and the Algolia code can sit side by side
- adding the necessary deps
- providing appropriate index and settings configuration
- modifying the `indexForSearch` action to know about Algolia
- modifying the `deleteCollection` action to know about Algolia

