### PR TITLE
chore: remove (leftover) SAILTHRU vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,6 @@ NODE_ENV=development
 PORT=4000
 DD_APM_ENABLED=false
 
-# Needed to push content to Sailthru - different versions exist for staging and
-# production instances!
-SAILTHRU_KEY=
-SAILTHRU_SECRET=
-
 # For connecting to Metaphysics, Artsy's GraphQL service, to retreive artwork
 # and artist data associated with a collection
 METAPHYSICS_URL=


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3663

Sailthru integration was removed in [this PR](https://github.com/artsy/kaws/pull/323) and this PR removes the remaining vars. Configmaps were also updated to unset these vars.

```
➜  kaws git:(master) hokusai staging env get | grep SAILTHRU
SAILTHRU_KEY=<REDACTED>
SAILTHRU_SECRET=<REDACTED>
➜  kaws git:(master) hokusai production env get | grep SAILTHRU
SAILTHRU_KEY=<REDACTED>
SAILTHRU_SECRET=<REDACTED>
➜  kaws git:(master) hokusai staging env unset SAILTHRU_KEY SAILTHRU_SECRET && hokusai staging env get SAILTHRU_KEY SAILTHRU_SECRET
➜  kaws git:(master) hokusai production env unset SAILTHRU_KEY SAILTHRU_SECRET && hokusai production env get SAILTHRU_KEY SAILTHRU_SECRET
```


