### PR TITLE
feat: add external ingress for consultant

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -138,6 +138,25 @@ spec:
               servicePort: http
 
 ---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kaws
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: kaws-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              serviceName: kaws-web-internal
+              servicePort: http
+
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1639601919079000

To provide consultant access to staging Kaws. Kaws' Ingress is internal, therefore not available over the Internet. One option is to give the consultant staging VPN access but that potentially allows the consultant access to anything staging (other apps, rabbitmq, elasticsearch, ...)

So we are experimenting with this alternative:
- Add an external Ingress that allows Cloudflare IPs only.
- Create Cloudflare DNS name `kaws-staging.artsy.net` pointing to `nginx-staging.artsy.net` (external Ingress controller). Enable Proxying.
- On Cloudflare, configure a firewall rule for `kaws-staging.artsy.net`, allowing the consultant's IP only.

Cloudflare firewall rule has been created, called `kaws-staging-ip-restriction`. Currently allowing my home IP as a test.

This PR is for creating the external Ingress.
