### PR TITLE
chore: bump mongodb to use 4.2

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - kaws-mongodb
   kaws-mongodb:
-    image: mongo:4.0
+    image: mongo:4.2
     ports:
       - "27017:27017"
-    command: ["--storageEngine=mmapv1", "--quiet", "--nojournal"]
+    command: ["--quiet", "--nojournal"]

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "9200:9200"
   kaws-mongodb:
-    image: mongo:4.4
+    image: mongo:4.2
     ports:
       - "27017:27017"
     command: ["--quiet", "--nojournal"]

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "9200:9200"
   kaws-mongodb:
-    image: mongo:4.2
+    image: mongo:4.4
     ports:
       - "27017:27017"
     command: ["--quiet", "--nojournal"]

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "9200:9200"
   kaws-mongodb:
-    image: mongo:4.0
+    image: mongo:4.2
     ports:
       - "27017:27017"
     command: ["--storageEngine=mmapv1", "--quiet", "--nojournal"]

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -23,4 +23,4 @@ services:
     image: mongo:4.2
     ports:
       - "27017:27017"
-    command: ["--storageEngine=mmapv1", "--quiet", "--nojournal"]
+    command: ["--quiet", "--nojournal"]

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "googleapis": "92.0.0",
     "graphql-yoga": "1.18.3",
     "lodash": "4.17.21",
-    "mongodb": "3.1.13",
+    "mongodb": "3.6.0",
     "mongodb-uri": "0.9.7",
     "morgan": "1.9.1",
     "node-fetch": "2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,14 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+bl@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-2.2.1.tgz#8c11a7b730655c5d56898cdc871224f40fd901d5"
+  integrity sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
 bluebird@^3.5.0:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
@@ -1575,7 +1583,7 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-bson@^1.1.0:
+bson@^1.1.4:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.6.tgz#fb819be9a60cd677e0853aee4ca712a785d6618a"
   integrity sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==
@@ -2547,6 +2555,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+denque@^1.4.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
+  integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -5652,29 +5665,23 @@ module-details-from-path@^1.0.3:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
   integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
 
-mongodb-core@3.1.11:
-  version "3.1.11"
-  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.11.tgz#b253038dbb4d7329f3d1c2ee5400bb0c9221fde5"
-  integrity sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==
-  dependencies:
-    bson "^1.1.0"
-    require_optional "^1.0.1"
-    safe-buffer "^5.1.2"
-  optionalDependencies:
-    saslprep "^1.0.0"
-
 mongodb-uri@0.9.7:
   version "0.9.7"
   resolved "https://registry.yarnpkg.com/mongodb-uri/-/mongodb-uri-0.9.7.tgz#0f771ad16f483ae65f4287969428e9fbc4aa6181"
   integrity sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE=
 
-mongodb@3.1.13:
-  version "3.1.13"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.13.tgz#f8cdcbb36ad7a08b570bd1271c8525753f75f9f4"
-  integrity sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==
+mongodb@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.0.tgz#babd7172ec717e2ed3f85e079b3f1aa29dce4724"
+  integrity sha512-/XWWub1mHZVoqEsUppE0GV7u9kanLvHxho6EvBxQbShXTKYF9trhZC2NzbulRGeG7xMJHD8IOWRcdKx5LPjAjQ==
   dependencies:
-    mongodb-core "3.1.11"
+    bl "^2.2.0"
+    bson "^1.1.4"
+    denque "^1.4.1"
+    require_optional "^1.0.1"
     safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
 
 morgan@1.9.1:
   version "1.9.1"
@@ -6617,6 +6624,19 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.5:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"


### PR DESCRIPTION
This PR sets Kaws' local dev and CI environments to use `mongodb@4.2`. This is in preparation for the eventual upgrade to `mongodb@5.0` on the shared K8 cluster.  It also updates the driver to `3.6`, as the previous version was not compatible with `4.2`, see compatibility chart [here](https://docs.mongodb.com/drivers/node/current/compatibility/).

[The test suite passed](https://app.circleci.com/pipelines/github/artsy/kaws/1127/workflows/580a74ed-50e3-4cc2-b10a-58996a289c0e/jobs/1762) and fetching appears to be working properly in the local `graphql` playground.

![2022-01-31 16 57 10](https://user-images.githubusercontent.com/38149304/151879893-75e8178e-19a6-431e-8746-a41d587548b0.gif)


[PLATFORM-3818]

[PLATFORM-3818]: https://artsyproduct.atlassian.net/browse/PLATFORM-3818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ