### PR TITLE
chore: bump mongodb to v4.4 in test (CI), dev

### DIFF
--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - kaws-mongodb
   kaws-mongodb:
-    image: mongo:4.2
+    image: mongo:4.4
     ports:
       - "27017:27017"
     command: ["--quiet", "--nojournal"]

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "9200:9200"
   kaws-mongodb:
-    image: mongo:4.2
+    image: mongo:4.4
     ports:
       - "27017:27017"
     command: ["--quiet", "--nojournal"]


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3951

This is in preparation for upgrading Mongo Atlas staging/prod to v4.4.

---

> Note1: As with the previous mongodb upgrade (to v4.2) this PR will need to be merged along with Positron and Kaws followed by announcement in #dev encouraging contributors to switch their local version to mongodb v4.4.
>
> As far as announcement goes, the recommendation is to completely remove the previous version and data and re-run setup to reduce the likelihood of conflicts between versions.
```
brew uninstall mongodb-community@4.2
rm -rf /usr/local/var/mongodb/*
cd ~/code/gravity && bin/setup
```

> Note2: [Starting with MongoDB 4.4](https://docs.mongodb.com/database-tools/#versioning), the MongoDB Database Tools are now released separately from the MongoDB Server and use their own versioning, with an initial version of 100.0.0. Previously, these tools were released alongside the MongoDB Server and used matching versioning.**